### PR TITLE
Fix fatal error in local git clone

### DIFF
--- a/home/bin/ghpsd
+++ b/home/bin/ghpsd
@@ -23,7 +23,7 @@ InitCheckoutDir() {
   git add .gitignore
   git commit -m "ignore .gh-pages"
 
-  git clone --local . .gh-pages
+  git clone --local --no-hardlinks . .gh-pages
   cd .gh-pages
   git checkout gh-pages --
 }


### PR DESCRIPTION
 failed to create link, Operation not permitted.
That was causing the script to crash and become useless during this git clone line. I found the solution online, so I thought I'd merge it in.