### PR TITLE
docs: correct the README after an independent review

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,20 @@ Everything that ends up in the home directory lives in [`rcm/`](rcm).
 A name there gains a leading dot on the way to `$HOME`,
 so `rcm/bashrc` becomes `~/.bashrc` and `rcm/ssh/config` becomes `~/.ssh/config`.
 
-The exceptions are listed in `UNDOTTED`:
+The exceptions are listed in the `UNDOTTED` variable in [`rcm/rcrc`](rcm/rcrc):
 `air.toml`, `bin`, `git`, `log` and `scriptlets` keep their names,
 so `rcm/bin/h` becomes `~/bin/h`.
 Naming a directory covers everything below it.
 
+`rcup` asks before replacing a file that already exists and differs
+(`[ynaq]` — `n` and Enter skip it, `y` replaces one, `a` replaces all without backup, `q` aborts).
+Identical files are linked silently, and files that do not exist yet are created without asking.
+
 ## Per-user overrides
 
 A `tag-<NAME>/` directory holds files for one account:
-[`rcm/tag-kirill/scriptlets/gitconfig`](rcm/tag-kirill) installs to `~/scriptlets/gitconfig`.
+[`rcm/tag-kirill/scriptlets/gitconfig`](rcm/tag-kirill/scriptlets/gitconfig)
+installs to `~/scriptlets/gitconfig`.
 
 [`rcm/rcrc`](rcm/rcrc) is sourced as shell, so it selects the tag itself:
 
@@ -40,20 +45,84 @@ TAGS="$(id -un)"
 ```
 
 An account with no matching `tag-` directory installs nothing extra.
-Tags are not limited to user names —
-`rcup -t work` or a `host-<hostname>/` directory work the same way.
+Tags are not limited to user names:
+`rcup -t work` selects a `tag-work/` directory *instead of* the per-user one,
+and a `host-<hostname>/` directory is picked up automatically like a tag.
+
+The three files under `~/scriptlets/` are read by the configuration that ships here —
+[`rcm/gitconfig`](rcm/gitconfig) includes `scriptlets/gitconfig`,
+[`rcm/ssh/config`](rcm/ssh/config) includes `~/scriptlets/ssh-config`,
+and [`rcm/Rprofile`](rcm/Rprofile) sources `~/scriptlets/Rprofile` if it exists.
+Each tolerates the file being absent,
+which is why an unknown account needs no tag directory.
 
 ## Files
 
-- [`rcm/rcrc`](rcm/rcrc): installed as `~/.rcrc`, and read directly by `make install`
-  on a machine that does not have it yet.
+- [`rcm/rcrc`](rcm/rcrc): sets `DOTFILES_DIRS`, `UNDOTTED` and `TAGS`,
+  and is installed as `~/.rcrc`.
+  Every `make` target also points `RCRC` at this copy, so it takes effect
+  even before — or instead of — an existing `~/.rcrc`.
+  It hardcodes `DOTFILES_DIRS="$HOME/git/scriptlets/rcm"`,
+  so a bare `rcup` or `lsrc` finds nothing unless the clone lives at `~/git/scriptlets`
+  (where [`bootstrap`](bootstrap) puts it).
+  `make` passes `-d` and works from any location.
 - [`rcm/log/dummy`](rcm/log): placeholder that brings `~/log` into existence.
   Keep the name dotless — rcm skips names starting with a dot.
 - [`Makefile`](Makefile): `make` links everything,
-  `make force` replaces existing files,
+  `make force` replaces existing files without asking,
   `make uninstall` runs `rcdn`,
   and `make check` lists the mapping without touching the filesystem.
-- [`bootstrap`](bootstrap): one-shot setup: clones the repo to `~/git/scriptlets` and runs `make`.
+  `make test` runs an install in a throwaway container, `make test-local` inside one.
+- [`bootstrap`](bootstrap): one-shot setup.
+  It requires `rcup` on `PATH`, **deletes any existing `~/git/scriptlets`**,
+  clones the repo there and runs `make`.
+
+`rcup` does not prune orphans:
+deleting a file from `rcm/` leaves a dangling symlink in `$HOME`.
+Run `make uninstall` *before* removing a file, or delete the stale link by hand.
+`make uninstall` also removes directories it leaves empty,
+walking up as far as `$HOME` itself — harmless on a real home directory,
+which always has unrelated content, but worth knowing in a container.
+
+## Prerequisites
+
+Beyond [rcm](https://github.com/thoughtbot/rcm),
+the scripts assume a GNU userland under Homebrew's `g` names:
+`h` and `s` need `fd`, `gsed`, `gsort` and GNU `parallel`;
+`fsed` needs `ag`, `gsed` and `gxargs`;
+`pmake` needs `gmake`; `git-merge-into` needs `gsed`;
+`n` and `bkg` need `terminal-notifier`; `rpt` needs `inotifywait` and `unbuffer`;
+`git-mmv` needs `mmv`; `imgdiff` needs ImageMagick.
+
+Nothing here puts `~/bin` on `PATH`.
+On Ubuntu the distribution's own `~/.profile` happens to add it;
+on macOS it does not, and zsh — the default login shell — reads none of the
+bash files shipped here, so add `~/bin` to `PATH` yourself.
+
+## Configuration files
+
+Alongside the scripts in `rcm/bin/`, these land in the home directory:
+
+| File | Installed as | |
+| --- | --- | --- |
+| [`bashrc`](rcm/bashrc), [`bash_profile`](rcm/bash_profile), [`bash_aliases`](rcm/bash_aliases) | `~/.bashrc`, `~/.bash_profile`, `~/.bash_aliases` | interactive bash: prompt, history, aliases |
+| [`autoscreen`](rcm/autoscreen) | `~/.autoscreen` | drop into `screen` automatically on an interactive SSH login |
+| [`gitconfig`](rcm/gitconfig), [`gitaliases`](rcm/gitaliases) | `~/.gitconfig`, `~/.gitaliases` | Git settings and aliases; pulls in several optional `~/.gitconfig.*` includes |
+| [`gitignore`](rcm/gitignore) | `~/.gitignore` | global excludes, wired up via `core.excludesfile` |
+| [`ssh/config`](rcm/ssh/config) | `~/.ssh/config` | keep-alives plus `Include`s for Colima, OrbStack and the per-user overrides |
+| [`Rprofile`](rcm/Rprofile) | `~/.Rprofile` | R defaults: CRAN mirror selection, `usethis`/`testthat`/`pillar` options, per-project `.lib` and `Makevars` hooks |
+| [`air.toml`](rcm/air.toml) | `~/air.toml` | fallback config for the `air` R formatter — formats nothing unless a project overrides it |
+| [`editorconfig`](rcm/editorconfig) | `~/.editorconfig` | indentation defaults |
+| [`vimrc`](rcm/vimrc), [`tigrc`](rcm/tigrc), [`toprc`](rcm/toprc) | `~/.vimrc`, `~/.tigrc`, `~/.toprc` | vim, tig and top |
+| [`screenrc`](rcm/screenrc), [`screenrc-xpra`](rcm/screenrc-xpra) | `~/.screenrc`, `~/.screenrc-xpra` | GNU screen; the second starts an `xpra` server in a window |
+| [`config/diffuse/diffuserc`](rcm/config/diffuse/diffuserc) | `~/.config/diffuse/diffuserc` | dark colour scheme for the Diffuse merge tool |
+| [`finicky.js`](rcm/finicky.js) | `~/.finicky.js` | per-URL browser routing via Finicky (macOS) |
+| [`git/R/`](rcm/git/R) | `~/git/R/` | CMake and build helpers for working on the R sources in CLion |
+
+Several of these source files that this repository does *not* ship —
+`~/.bash_secrets`, `~/git/bash-git-prompt`, `~/git/complete-alias` —
+without guarding for their absence,
+so a fresh shell reports errors until they exist or the lines are removed.
 
 # Coming from the previous version
 
@@ -72,8 +141,10 @@ The previous layout is preserved on the
 | `home/dot-ssh/config` | `rcm/ssh/config` |
 | `home/bin/h` | `rcm/bin/h` — `bin` is in `UNDOTTED`, so the name is kept |
 | `personalized/<USER>/gitconfig` | `rcm/tag-<USER>/scriptlets/gitconfig` |
-| `make build`, then `./install` | `make` |
+| `make` | `make` — unchanged |
+| `make build` (regenerate the installers) | — nothing to regenerate |
 | `make run-force-install` | `make force` |
+| `make run-quiet-install` | — no target; `rcup -q` |
 | — | `make uninstall`, `make check` |
 
 The principal differences:
@@ -82,9 +153,15 @@ The principal differences:
 - **`make-install`, `install` and `install-personalized` are gone.**
   The two installers were generated files that had to be refreshed with `make build`
   after every change; rcm links straight out of `rcm/`, so there is nothing to regenerate.
-- **Removing a file now removes its link.**
-  `make uninstall` (`rcdn`) unlinks everything, and `make force` replaces existing files;
-  the old installer could only add.
+- **Uninstalling is now possible.**
+  `make uninstall` (`rcdn`) unlinks everything rcm currently owns,
+  and `make force` replaces existing files; the old installer could only add.
+  Neither installer prunes orphans, so a file deleted from `rcm/`
+  still leaves its link behind — see the note above.
+- **Existing files are no longer skipped in silence.**
+  The old installer left any pre-existing file alone and moved on;
+  `rcup` asks what to do with one that differs.
+  A first run on a machine that already has a `~/.gitconfig` will stop and prompt.
 - **The tag is chosen with `id -un` rather than `$USER`,**
   so it also works where `$USER` is unset, such as launchd jobs
   and some non-interactive sessions.
@@ -107,7 +184,8 @@ Currently macOS only.
 
 ## h and s
 
-Iterate over all worktrees under the current Git repository and execute a command in each of them.
+Find every Git repository below the current directory and execute a command in each of them.
+Linked worktrees are included, since they carry a `.git` file.
 With `h`, the command is executed directly.
 The `s` command prepends `git`, it is a wrapper around `h git` .
 Supported switches:
@@ -116,6 +194,7 @@ Supported switches:
 - `-p` or `--paged`: show the output of the command in a pager (with aliases `hp` and `sp`)
 - `-n` or `--dry-run`: show the command that would be executed, but do not execute it
 - `-x` or `--log-commands`: also log the commands that are executed
+- `-u` or `--unsorted`: skip the sort/dedup pass over the discovered repositories
 - `--color=auto|always|never`, `--no-color`: control colored output. Default is `auto`: color is enabled when stdout is a TTY (or `--paged` is set), and disabled otherwise. The `NO_COLOR` environment variable (https://no-color.org/) also disables color unless `--color=always` is given.
 
 `gita` both does too much and not enough, let's see how far I can get with home-grown scripts.
@@ -131,7 +210,8 @@ If no project file is found, it is created using `usethis::use_rstudio()`.
 
 ## fsed
 
-Run `gsed` on files in subdirectories.
+Run `gsed` over the whole tree below the current directory, `.git` excluded.
+Files are discovered with `ag`.
 
 ## air-format
 
@@ -160,7 +240,8 @@ Colorful `egrep` .
 
 ## pdfcat
 
-Concatenate multiple PDF files into a single document.
+Dump the text of a single PDF file to stdout, a thin wrapper around `pdftotext`.
+The name is a misnomer: it concatenates nothing.
 
 ## git-bubble
 
@@ -239,10 +320,11 @@ Connects to remote machines and shows the top 5 processes by CPU consumption.
 ## ogv-to-gif
 
 Convert a video to an animated GIF.
+Currently broken: the script exits after the frame-export step, and the rest is unreachable.
 
 ## slecho
 
-Echoes each of its parameters on a single line.
+Echoes each of its parameters on a line of its own.
 
 ## rpt
 
@@ -316,7 +398,7 @@ Join multiple Git repositories into one while preserving history.
 
 # Obsolete
 
-In the [`obsolete`](obsolete) directory.
+In the [`obsolete`](obsolete) directory, catalogued in [`obsolete/README.md`](obsolete/README.md).
 
 
 


### PR DESCRIPTION
An independent review of the README on merged `main`, done with no knowledge of how it got written. Every claim below was re-verified here against the scripts or a scratch `$HOME` run before being changed.

## The one that matters

The migration section stated **the opposite of what happens**, on its headline benefit over the old installer:

> **Removing a file now removes its link.**

It does not. `rcup` has no orphan-cleaning pass. Verified:

```
install into a scratch $HOME  →  ~/.vimrc -> repo/rcm/vimrc
rm rcm/vimrc && make install  →  ~/.vimrc still present, no longer resolves
```

The only way to drop the link is `rcdn` *before* deleting the source. The bullet now says uninstalling is possible and warns that `make uninstall` has to run first. That sentence was mine, added in the last README commit — sorry.

## Other corrections

Each checked against the script or a scratch run, not against the prose:

| Claim | Reality |
|---|---|
| `pdfcat` — "Concatenate multiple PDF files into a single document" | the script is `pdftotext "$1" -` — dumps the text of *one* PDF. Wrong since `000877e`, not a migration regression |
| `h`/`s` — "all worktrees under the current Git repository" | `fd -HILg .git` over the *current directory tree*; the cwd is normally a directory of clones, not a checkout |
| `rcup -t work` … "work the same way" | `-t` selects `tag-work/` **instead of** the per-user tag, not in addition — surprising, given `TAGS="$(id -un)"` is the whole design |
| "listed in `UNDOTTED`" | `UNDOTTED` is a shell variable in `rcm/rcrc`, not a file — the reference had nothing to click |
| `rcrc` "read directly by `make install`" | all four `make` targets set `RCRC`, and it overrides `~/.rcrc` unconditionally |
| `make build`, then `./install` → `make` | plain `make` installed before the migration too; `make build` was the *regeneration* step. Row split |
| `slecho` "on a single line" | one parameter per line |
| `fsed` "files in subdirectories" | whole tree from the cwd, `.git` excluded, discovered with `ag` |
| `ogv-to-gif` "Convert a video to an animated GIF" | exits before the conversion; everything after is dead code |
| `h` switches | `-u` / `--unsorted` was undocumented |
| link `[rcm/tag-kirill/scriptlets/gitconfig](rcm/tag-kirill)` | text named a file, href pointed at a directory |

Also documented, all previously silent: `DOTFILES_DIRS` hardcodes `$HOME/git/scriptlets/rcm`, so a bare `rcup` from a clone elsewhere **silently does nothing**; and `make uninstall` prunes empty parent directories as far up as `$HOME` (harmless on a real home directory — verified unrelated files and their directories survive).

## Additions

- **The `[ynaq]` overwrite prompt.** The old installer skipped pre-existing files in silence; `rcup` asks about any that differ. This is exactly what you hit running `bootstrap` on the new Mac. Now documented in Layout *and* called out in the migration section, since it is a behaviour change a returning user will meet on their first run.
- **What reads `~/scriptlets/`** — `rcm/gitconfig` includes it, `rcm/ssh/config` includes it, `rcm/Rprofile` sources it. The section said where the files land but never what consumes them.
- **A prerequisites section.** `h`, the flagship tool, needs `fd`, `gsed`, `gsort` and GNU `parallel`; the `g*` names are Homebrew conventions that do not exist on a stock Ubuntu. Worth weighing against line 4's "Tested with current Ubuntu and macOS".
- **`~/bin` is never put on `PATH` by anything here.** On Ubuntu the distro's own `~/.profile` happens to add it; on macOS it does not, and zsh reads none of the bash files shipped here. Given the README's first instruction is "install all scripts to `~/bin`", this was the biggest missing sentence.
- **A configuration-file table.** Line 3 promises "shell scripts *and configuration files*", and the catalogue documented only `bin/` scripts. Twenty config files ship; none was described.
- A note that `bash_aliases` and `bashrc` unconditionally source three files this repo does not ship (`~/.bash_secrets`, `~/git/bash-git-prompt`, `~/git/complete-alias`), so a fresh shell reports errors until they exist.

Verified after editing: every relative link resolves on `main`, the config table covers every non-`bin` file that installs, and `make install` still produces 70 links with none broken.

## Not done

- **`bootstrap` still blocks on the prompt.** This PR documents the behaviour; it does not change it. Making `bootstrap` preview conflicts before touching anything is a code change — happy to do it separately, since it needs a decision about whether a piped `curl … | sh` should ever prompt.
- **The unguarded `source` lines are only documented, not fixed.** Guarding them touches shell config, not docs.
- Two pre-existing long lines (the `--color` bullet, the `git-bifurcate` paragraph) still violate the repo's semantic-line-break convention. Left alone to keep the diff on-topic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01143RSSP82ZXAFmWuf3czSB)_