### PR TITLE
fix(bootstrap): let rcm's prompts reach the terminal

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -8,10 +8,35 @@ command -v rcup >/dev/null || {
   exit 1
 }
 
+# Piped into a shell (curl ... | sh), stdin is the download, not the terminal.
+# rcup asks before replacing a file that already exists and differs, and reads
+# the answer from stdin -- so without this it would consume the rest of this
+# script as the answer, or hit end-of-file and silently skip every conflict.
+# Test that /dev/tty can actually be opened: -r only checks permissions, and
+# the device node is readable but unopenable where there is no controlling
+# terminal (containers, CI, cron), where `exec < /dev/tty` would abort.
+if [ ! -t 0 ] && (exec < /dev/tty) 2>/dev/null; then
+  exec < /dev/tty
+fi
+
 cd
 mkdir -p git
 cd git
 rm -rf scriptlets
 git clone https://github.com/krlmlr/scriptlets.git
 cd scriptlets
+
+set +x
+echo
+echo "Installing with rcm. Any file that already exists in your home directory"
+echo "and differs from the one shipped here will be shown as:"
+echo
+echo "    overwrite ~/.gitconfig? [ynaq]"
+echo
+echo "  y = replace it   n / Enter = keep yours   a = replace all   q = stop"
+echo
+echo "Answering 'a' replaces every conflicting file without keeping a backup."
+echo
+set -x
+
 make


### PR DESCRIPTION
Fixes the failure you hit running `curl … | sh` on the new Mac: the prompt appears and cannot be answered.

## Cause

Piped into a shell, **stdin is the download, not the terminal**. `rcup` asks before replacing a file that already exists and differs, and reads the answer from stdin — so the `read` either consumes whatever is left of the bootstrap script as the answer, or hits end-of-file and falls through to the "skip" branch.

Reproduced against a scratch `$HOME` containing a pre-existing `~/.gitconfig`:

```
$ echo "" | sh -c 'make install'
overwrite …/.gitconfig? [ynaq]
→ gitconfig: skipped silently   other links: 69
```

So the visible symptom is a dead prompt, and the invisible one is that the conflicting file is quietly left alone while everything else installs.

## Fix

Reattach stdin to the controlling terminal before `make`:

```sh
if [ ! -t 0 ] && (exec < /dev/tty) 2>/dev/null; then
  exec < /dev/tty
fi
```

The guard **opens** `/dev/tty` in a subshell rather than testing `-r`. My first attempt used `[ -r /dev/tty ]` and was wrong: `-r` only checks permissions, and the device node is readable but *unopenable* where there is no controlling terminal — a container, CI, cron. There `exec < /dev/tty` fails with `No such device or address` and `set -e` aborts the whole bootstrap. Caught by testing that path rather than only the happy one.

Verified both ways, the second under a real pty:

| Environment | Result |
|---|---|
| piped stdin, no controlling terminal | guard declines, script completes, exit 0, 69 links |
| piped stdin, controlling terminal present | prompt answered from the keyboard (`got: [y]`), and the script body is **no longer** consumed as the answer |

## Also

`bootstrap` now explains the prompt before `make` runs, since `a` replaces every conflicting file **without keeping a backup**:

```
    overwrite ~/.gitconfig? [ynaq]

  y = replace it   n / Enter = keep yours   a = replace all   q = stop
```

## Note

This keeps the prompt, per your call that `curl | sh` should prompt. The alternative — a non-interactive bootstrap that previews conflicts and never asks — is a different design; say the word if you'd rather have that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01143RSSP82ZXAFmWuf3czSB)_