### PR TITLE
feat: put `~/bin` on the `PATH` on macOS too, and check it in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,12 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # zsh comes with macOS; on Ubuntu it is installed so that the checks
+      # cover it there too, rather than skipping it.
       - name: Install rcm
         run: |
           case "$RUNNER_OS" in
           Linux)
             sudo apt-get update
-            sudo apt-get install -y rcm
+            sudo apt-get install -y rcm zsh
             ;;
           macOS)
             brew install rcm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,47 @@
+name: test
+
+# The point of running on both: on Ubuntu the scripts are found because the
+# stock ~/.profile puts ~/bin on the PATH, on macOS only because this
+# repository ships the equivalent. Only the macOS job notices when that
+# equivalent breaks.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install rcm
+        run: |
+          case "$RUNNER_OS" in
+          Linux)
+            sudo apt-get update
+            sudo apt-get install -y rcm
+            ;;
+          macOS)
+            brew install rcm
+            ;;
+          esac
+
+      # tests/run installs into a home directory of its own, so nothing here
+      # depends on -- or disturbs -- the runner's own home directory.
+      - name: Run checks
+        run: make test-local

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,13 @@ check:
 uninstall:
 	$(RCM) rcdn $(DOTDIR)
 
+# The same suite in a container, for a Linux run from a machine that is not
+# Linux. CI covers Ubuntu and macOS; this is for a quick check in between.
 test:
 	docker run --rm -v $(shell pwd):/scriptlets -w /scriptlets buildpack-deps:latest \
 	  sh -c 'apt-get update && apt-get install -y rcm && make test-local'
 
+# Install into a throw-away home directory and run the checks against it. The
+# home directory of whoever runs this is left alone.
 test-local:
-	make install
-	ls -lRa $${HOME}
-	make install
-	ls -lRa $${HOME}
-	make force
-	ls -lRa $${HOME}
+	./tests/run

--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ The exceptions are listed in the `UNDOTTED` variable in [`rcm/rcrc`](rcm/rcrc):
 so `rcm/bin/h` becomes `~/bin/h`.
 Naming a directory covers everything below it.
 
+## PATH
+
+The scripts land in `~/bin`, which no system puts on the `PATH` on its own.
+
+Ubuntu's stock `~/.profile` prepends `~/bin` and then `~/.local/bin`
+if the directories exist,
+so `~/.local/bin` ends up in front of `~/bin`.
+macOS has no counterpart:
+`/usr/libexec/path_helper`, run from `/etc/zprofile` and `/etc/profile`,
+builds the `PATH` from `/etc/paths` and `/etc/paths.d`,
+both system-wide,
+and never looks below `$HOME`.
+Neither `~/bin` nor `~/.local/bin` is special there.
+
+[`rcm/profile`](rcm/profile) closes the gap:
+it mirrors what Ubuntu does,
+so `~/bin` works the same on both platforms
+and [`rcm/bash_profile`](rcm/bash_profile) has the `~/.profile` it sources.
+
+`~/bin` stays the install target rather than `~/.local/bin`.
+Moving would gain nothing on macOS, where neither directory is automatic,
+and nothing on Ubuntu, where both already are.
+It would cost a directory of our own:
+`~/.local/bin` is shared with `pipx`, `uv` and `pip install --user`,
+while `make uninstall` (`rcdn`) is best pointed at a directory only rcm writes to.
+
 ## Per-user overrides
 
 A `tag-<NAME>/` directory holds files for one account:
@@ -51,6 +77,9 @@ and a `host-<hostname>/` directory is picked up automatically like a tag.
   and is installed as `~/.rcrc`.
   Every `make` target also points `RCRC` at this copy, so it takes effect
   even before — or instead of — an existing `~/.rcrc`.
+- [`rcm/profile`](rcm/profile): installed as `~/.profile`,
+  puts `~/bin` and `~/.local/bin` on the `PATH` and sources `~/.bashrc` under bash.
+  Equivalent to Ubuntu's stock file, and the piece macOS lacks.
 - [`rcm/log/dummy`](rcm/log): placeholder that brings `~/log` into existence.
   Keep the name dotless — rcm skips names starting with a dot.
 - [`Makefile`](Makefile): `make` links everything,

--- a/README.md
+++ b/README.md
@@ -112,10 +112,16 @@ on Ubuntu the scripts are found because the stock `~/.profile` finds them,
 on macOS only because this repository ships the equivalent,
 so a break in `rcm/profile` or `rcm/zprofile` shows up in the macOS job alone.
 
-[`tests/run`](tests/run) creates the home directory,
-seeding it from `/etc/skel` where that exists —
-which is what `useradd -m` does,
-and the reason a fresh Ubuntu account has a `~/.profile` while a macOS one does not.
+[`tests/run`](tests/run) creates the home directory
+and seeds it the way a stock account is seeded:
+on Ubuntu with `.bashrc`, `.profile` and `.bash_logout` from `/etc/skel`,
+which is what `useradd -m` copies,
+on macOS with nothing at all.
+The three are taken by name rather than wholesale,
+because `/etc/skel` is also where an image builder drops extras —
+the CI runner's `/etc/skel` carries a `~/.bash_profile` no stock Ubuntu account has,
+and seeding it would test the CI image instead of the platform.
+
 Each file in `tests/checks` is a separate script
 that sources [`tests/lib.sh`](tests/lib.sh) for `pass`, `fail` and the assertions,
 and they run in name order:
@@ -124,6 +130,9 @@ and they run in name order:
   account may log in with, and they run.
 - `20-install`: every destination rcm lists exists, configuration files are
   symbolic links, and installing twice changes nothing.
+- `30-preexisting`: an account that came with its own `~/.bash_profile` keeps it,
+  and `make force` is what makes the scripts reachable there.
+  It brings its own home directory.
 - `90-force`: `make force` replaces the files rcm skipped,
   and the scripts are still found afterwards.
   It runs last because it is the one check that rewrites what the others read.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Neither `~/bin` nor `~/.local/bin` is special there.
 it mirrors what Ubuntu does,
 so `~/bin` works the same on both platforms
 and [`rcm/bash_profile`](rcm/bash_profile) has the `~/.profile` it sources.
+[`rcm/zprofile`](rcm/zprofile) does the same for zsh,
+the default shell on macOS since Catalina,
+which never reads `~/.profile` on its own.
+rcm skips a file the account already has,
+so a machine that came with its own `~/.profile` keeps it until `make force`.
 
 `~/bin` stays the install target rather than `~/.local/bin`.
 Moving would gain nothing on macOS, where neither directory is automatic,
@@ -80,13 +85,52 @@ and a `host-<hostname>/` directory is picked up automatically like a tag.
 - [`rcm/profile`](rcm/profile): installed as `~/.profile`,
   puts `~/bin` and `~/.local/bin` on the `PATH` and sources `~/.bashrc` under bash.
   Equivalent to Ubuntu's stock file, and the piece macOS lacks.
+- [`rcm/zprofile`](rcm/zprofile): installed as `~/.zprofile`,
+  hands `~/.profile` to zsh, which would not read it otherwise.
 - [`rcm/log/dummy`](rcm/log): placeholder that brings `~/log` into existence.
   Keep the name dotless — rcm skips names starting with a dot.
 - [`Makefile`](Makefile): `make` links everything,
   `make force` replaces existing files,
   `make uninstall` runs `rcdn`,
-  and `make check` lists the mapping without touching the filesystem.
+  `make check` lists the mapping without touching the filesystem,
+  and `make test-local` runs the checks described below.
 - [`bootstrap`](bootstrap): one-shot setup: clones the repo to `~/git/scriptlets` and runs `make`.
+
+## Tests
+
+`make test-local` installs everything into a throw-away home directory
+and runs the checks in [`tests/checks`](tests/checks) against it.
+The real home directory is never touched,
+so the checks are safe to run on the machine you use.
+`make test` does the same inside a container,
+for a Linux run from a machine that is not Linux.
+
+[`.github/workflows/test.yaml`](.github/workflows/test.yaml) runs them
+on Ubuntu and on macOS.
+Both matter:
+on Ubuntu the scripts are found because the stock `~/.profile` finds them,
+on macOS only because this repository ships the equivalent,
+so a break in `rcm/profile` or `rcm/zprofile` shows up in the macOS job alone.
+
+[`tests/run`](tests/run) creates the home directory,
+seeding it from `/etc/skel` where that exists —
+which is what `useradd -m` does,
+and the reason a fresh Ubuntu account has a `~/.profile` while a macOS one does not.
+Each file in `tests/checks` is a separate script
+that sources [`tests/lib.sh`](tests/lib.sh) for `pass`, `fail` and the assertions,
+and they run in name order:
+
+- `10-path`: the scripts are on the `PATH` of a login shell, in every shell an
+  account may log in with, and they run.
+- `20-install`: every destination rcm lists exists, configuration files are
+  symbolic links, and installing twice changes nothing.
+- `90-force`: `make force` replaces the files rcm skipped,
+  and the scripts are still found afterwards.
+  It runs last because it is the one check that rewrites what the others read.
+
+Adding a file to `tests/checks` is enough;
+`tests/run 10-path` runs one check by name,
+and `KEEP_TEST_HOME=1` leaves the home directory behind to look at.
 
 # Coming from the previous version
 

--- a/rcm/profile
+++ b/rcm/profile
@@ -1,0 +1,41 @@
+# ~/.profile: read by login shells, and by ~/.bash_profile explicitly.
+#
+# Ubuntu ships a stock ~/.profile that puts ~/bin and ~/.local/bin on the PATH.
+# macOS ships nothing of the sort: there, the PATH is assembled by
+# /usr/libexec/path_helper from /etc/paths and /etc/paths.d, both system-wide,
+# and no directory below $HOME is ever consulted.
+# This file makes the two platforms agree,
+# so ~/bin works on macOS without hand-written dotfiles outside this repository.
+#
+# rcm skips a file that already exists,
+# so an Ubuntu box keeps its stock ~/.profile unless `make force` is used.
+# The two are kept equivalent on purpose: same order, same conditions.
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+
+# set PATH so it includes user's private bin if it exists
+#
+# The case guard is the one deviation from the stock file:
+# a login shell started from a shell that already ran this file
+# (screen, ssh to localhost, `bash -l`)
+# would otherwise prepend the same entry again on every nesting level.
+if [ -d "$HOME/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/bin:"*) ;;
+        *) PATH="$HOME/bin:$PATH" ;;
+    esac
+fi
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/.local/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *) PATH="$HOME/.local/bin:$PATH" ;;
+    esac
+fi

--- a/rcm/zprofile
+++ b/rcm/zprofile
@@ -1,0 +1,13 @@
+# ~/.zprofile: read by login zsh shells.
+#
+# zsh has been the default shell on macOS since Catalina,
+# and it never reads ~/.profile,
+# so without this file the PATH set up there is missed entirely.
+#
+# ~/.zprofile is the right place rather than ~/.zshenv:
+# macOS runs /usr/libexec/path_helper from /etc/zprofile,
+# after ~/.zshenv and before this file,
+# and path_helper rebuilds the PATH from /etc/paths and /etc/paths.d,
+# pushing anything set earlier to the back.
+
+emulate sh -c '. "$HOME/.profile"'

--- a/tests/checks/10-path.sh
+++ b/tests/checks/10-path.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# The scripts must be reachable by name in a login shell, with nothing
+# configured by hand. This is the property that quietly did not hold on macOS:
+# a default installation puts no directory below $HOME on the PATH, because
+# /usr/libexec/path_helper only ever reads /etc/paths and /etc/paths.d.
+#
+# The shells covered are the ones a fresh account may log in with: bash is the
+# default on Ubuntu, zsh on macOS since Catalina, and /bin/sh stands in for
+# everything that reads ~/.profile alone.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+for shell in sh bash zsh; do
+    if ! command -v "$shell" >/dev/null 2>&1; then
+        skip "$shell: not installed"
+        continue
+    fi
+
+    path=$(login_path "$shell")
+
+    assert_in_path "$shell: ~/bin is on the PATH of a login shell" \
+        "$HOME/bin" "$path"
+
+    unresolved=
+    for script in "$REPO"/rcm/bin/*; do
+        name=${script##*/}
+        resolved=$(
+            PATH=$path
+            command -v "$name" 2>/dev/null || true
+        )
+        if [ "$resolved" != "$HOME/bin/$name" ]; then
+            unresolved="$unresolved $name"
+        fi
+    done
+
+    if [ -z "$unresolved" ]; then
+        pass "$shell: every script in rcm/bin resolves to ~/bin"
+    else
+        fail "$shell: every script in rcm/bin resolves to ~/bin" \
+            "not resolved:$unresolved"
+    fi
+done
+
+# Beyond being found, a script has to run. `g` forwards to git, which every
+# machine running these checks has.
+assert_equal "a script found on the PATH runs" \
+    "$(git --version)" \
+    "$(login_output bash 'g --version')"

--- a/tests/checks/10-path.sh
+++ b/tests/checks/10-path.sh
@@ -45,6 +45,15 @@ done
 
 # Beyond being found, a script has to run. `g` forwards to git, which every
 # machine running these checks has.
-assert_equal "a script found on the PATH runs" \
-    "$(git --version)" \
-    "$(login_output bash 'g --version')"
+#
+# Both versions are read inside the login shell, not one there and one here:
+# the git a login shell finds is not always the git this script finds. On macOS
+# it is Apple's, while the checkout was made with the one from Homebrew.
+git_version=$(login_output bash 'git --version')
+
+if [ -z "$git_version" ]; then
+    fail "a script found on the PATH runs" "a login shell finds no git at all"
+else
+    assert_equal "a script found on the PATH runs" \
+        "$git_version" "$(login_output bash 'g --version')"
+fi

--- a/tests/checks/20-install.sh
+++ b/tests/checks/20-install.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# What `make install` promises, it delivers: every destination rcm lists is
+# really there, the scripts are executable, and installing twice changes
+# nothing.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+mapping=$(make -s -C "$REPO" check)
+
+missing=
+for dest in $(printf '%s\n' "$mapping" | cut -d: -f1); do
+    if [ ! -e "$dest" ]; then
+        missing="$missing $dest"
+    fi
+done
+
+if [ -z "$missing" ]; then
+    pass "every destination rcm lists exists"
+else
+    fail "every destination rcm lists exists" "missing:$missing"
+fi
+
+# ~/.gitconfig is not part of /etc/skel anywhere, so it is always ours: a
+# symbolic link, which is what makes editing a file in the repository take
+# effect immediately.
+if [ -L "$HOME/.gitconfig" ]; then
+    pass "config files are symbolic links into the repository"
+else
+    fail "config files are symbolic links into the repository" \
+        "$(ls -l "$HOME/.gitconfig" 2>&1)"
+fi
+
+# ~/log exists only because rcm/log/dummy drags it into being.
+if [ -d "$HOME/log" ]; then
+    pass "~/log is created"
+else
+    fail "~/log is created" "no such directory"
+fi
+
+not_executable=
+for script in "$HOME"/bin/*; do
+    if [ ! -x "$script" ]; then
+        not_executable="$not_executable ${script##*/}"
+    fi
+done
+
+if [ -z "$not_executable" ]; then
+    pass "every script in ~/bin is executable"
+else
+    fail "every script in ~/bin is executable" "not executable:$not_executable"
+fi
+
+assert_ok "installing twice succeeds" make -C "$REPO" install
+assert_equal "installing twice changes nothing" \
+    "$mapping" "$(make -s -C "$REPO" check)"

--- a/tests/checks/30-preexisting.sh
+++ b/tests/checks/30-preexisting.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# An account that came with its own ~/.bash_profile is the one case where
+# `make install` alone is not enough: bash reads ~/.bash_profile *instead of*
+# ~/.profile, rcm leaves a file that already exists alone, and the scripts stay
+# out of reach until `make force` replaces it.
+#
+# Fedora and Amazon Linux seed such a file, and so does the GitHub Actions
+# Ubuntu runner -- stock Ubuntu and macOS do not. Both halves of the behaviour
+# are deliberate, so this checks them instead of working around them.
+#
+# The check brings its own home directory: it must not disturb the one the
+# other checks look at.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+other=$(mktemp -d "${TMPDIR:-/tmp}/scriptlets-preexisting.XXXXXX")
+
+(
+    HOME=$other
+    export HOME
+
+    # The shape those systems ship: a login file that reaches ~/.bashrc and
+    # never looks at ~/.profile.
+    printf '# .bash_profile\n[ -f ~/.bashrc ] && . ~/.bashrc\n' >"$HOME/.bash_profile"
+
+    assert_ok "make install succeeds on such an account" \
+        make -C "$REPO" install
+
+    if [ -L "$HOME/.bash_profile" ]; then
+        fail "make install keeps the ~/.bash_profile the account came with" \
+            "replaced by $(readlink "$HOME/.bash_profile")"
+    else
+        pass "make install keeps the ~/.bash_profile the account came with"
+    fi
+
+    assert_ok "make force succeeds on such an account" \
+        make -C "$REPO" force
+
+    assert_in_path "bash: ~/bin is on the PATH once make force replaced it" \
+        "$HOME/bin" "$(login_path bash)"
+)
+
+rm -rf "$other"

--- a/tests/checks/90-force.sh
+++ b/tests/checks/90-force.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# `make force` replaces the files rcm skipped because the account already had
+# them -- on Ubuntu that is the handful seeded from /etc/skel, notably
+# ~/.profile and ~/.bashrc. The scripts must still be found afterwards, which
+# is the configuration a macOS account is in from the start: every file in the
+# home directory comes from this repository.
+#
+# This check runs last on purpose: it is the only one that replaces files the
+# earlier checks look at.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+assert_ok "make force succeeds" make -C "$REPO" force
+
+for name in profile zprofile bashrc bash_profile; do
+    dest=$HOME/.$name
+    if [ "$(readlink "$dest" 2>/dev/null)" = "$REPO/rcm/$name" ]; then
+        pass "make force links ~/.$name into the repository"
+    else
+        fail "make force links ~/.$name into the repository" \
+            "$(ls -l "$dest" 2>&1)"
+    fi
+done
+
+for shell in sh bash zsh; do
+    if ! command -v "$shell" >/dev/null 2>&1; then
+        skip "$shell: not installed"
+        continue
+    fi
+
+    assert_in_path "$shell: ~/bin is still on the PATH after make force" \
+        "$HOME/bin" "$(login_path "$shell")"
+done

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,71 @@
+# Assertion helpers, sourced by every check in tests/checks.
+#
+# `tests/run` exports REPO, HOME (a throw-away home directory with the
+# repository installed into it) and TEST_FAILURES.
+# Failures are appended to the $TEST_FAILURES file rather than counted in a
+# variable, because each check runs in its own process.
+
+pass() {
+    printf 'ok       %s\n' "$1"
+}
+
+fail() {
+    printf 'NOT OK   %s\n' "$1"
+    if [ $# -gt 1 ]; then
+        printf '%s\n' "$2" | sed 's/^/         /'
+    fi
+    printf '%s\n' "$1" >>"$TEST_FAILURES"
+}
+
+skip() {
+    printf 'skip     %s\n' "$1"
+}
+
+# assert_equal DESCRIPTION EXPECTED ACTUAL
+assert_equal() {
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "expected: $2
+  actual: $3"
+    fi
+}
+
+# assert_in_path DESCRIPTION DIRECTORY PATH_VALUE
+assert_in_path() {
+    case ":$3:" in
+    *":$2:"*)
+        pass "$1"
+        ;;
+    *)
+        fail "$1" "PATH=$3"
+        ;;
+    esac
+}
+
+# login_output SHELL COMMAND -- what COMMAND prints in a login shell of SHELL.
+#
+# The marker line is what keeps banners and other login-time chatter (a bare
+# `echo` in /etc/profile.d is enough) out of the answer; the leading newline
+# covers chatter that ends without one. Only the last line of COMMAND's output
+# survives, which is all any check here needs.
+login_output() {
+    "$1" -lc 'printf "\nscriptlets-output=%s\n" "$('"$2"')"' 2>/dev/null |
+        sed -n 's/^scriptlets-output=//p' | tail -n 1
+}
+
+# login_path SHELL -- the PATH a login shell of SHELL arrives at.
+login_path() {
+    login_output "$1" 'printf %s "$PATH"'
+}
+
+# assert_ok DESCRIPTION COMMAND [ARGUMENT...]
+assert_ok() {
+    _description=$1
+    shift
+    if _output=$("$@" 2>&1); then
+        pass "$_description"
+    else
+        fail "$_description" "$_output"
+    fi
+}

--- a/tests/run
+++ b/tests/run
@@ -32,21 +32,39 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# What a fresh account starts with. `useradd -m` seeds it from /etc/skel, which
-# is where Ubuntu's stock ~/.profile -- the file that puts ~/bin on the PATH --
-# comes from. macOS has no /etc/skel and gives a new account no shell dotfiles
-# at all, which is the case these checks exist to cover.
-if [ -d /etc/skel ]; then
-    cp -R /etc/skel/. "$TEST_HOME"/
-fi
+# What a stock account starts with:
+#
+#   Ubuntu -- .bashrc, .profile and .bash_logout, copied from /etc/skel by
+#             `useradd -m`. The ~/.profile from there is what puts ~/bin on the
+#             PATH on a machine that has never been touched.
+#   macOS  -- nothing at all. There is no /etc/skel, and a new account gets no
+#             shell dotfiles, which is the case these checks exist to cover.
+#
+# The three files are named rather than copied wholesale, because /etc/skel is
+# also where an image builder drops extras: the GitHub Actions Ubuntu runner
+# ships a ~/.bash_profile that no stock Ubuntu account has. bash reads
+# ~/.bash_profile *instead of* ~/.profile, so seeding that file would test the
+# CI image rather than the platform. The case is covered on purpose in
+# tests/checks/30-preexisting.sh instead.
+seeded=
+for name in .bashrc .profile .bash_logout; do
+    if [ -f "/etc/skel/$name" ]; then
+        cp "/etc/skel/$name" "$TEST_HOME/$name"
+        seeded="$seeded $name"
+    fi
+done
 
 HOME=$TEST_HOME
 export HOME
 
-echo "# repo: $REPO"
-echo "# home: $TEST_HOME"
+echo "# repo:   $REPO"
+echo "# home:   $TEST_HOME"
+echo "# seeded:${seeded:- nothing}"
 echo "# make install"
-make -C "$REPO" install >/dev/null
+
+# Stdin comes from /dev/null throughout: rcup asks before replacing a file that
+# already exists and differs, and a check must never wait for an answer.
+make -C "$REPO" install >/dev/null </dev/null
 
 status=0
 
@@ -59,7 +77,7 @@ for check in "$REPO"/tests/checks/*.sh; do
     fi
 
     echo "# $name"
-    sh "$check" || status=1
+    sh "$check" </dev/null || status=1
 done
 
 failures=$(wc -l <"$TEST_FAILURES" | tr -d ' ')

--- a/tests/run
+++ b/tests/run
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Install this repository into a throw-away home directory that looks like a
+# brand-new account, then run every check in tests/checks against it.
+#
+# Usage:
+#   tests/run            run every check
+#   tests/run 10-path    run the named checks only
+#
+# KEEP_TEST_HOME=1 leaves the home directory behind for inspection.
+
+set -eu
+
+REPO=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+export REPO
+
+if ! command -v rcup >/dev/null; then
+    echo "rcm is required: apt install rcm / brew install rcm" >&2
+    exit 1
+fi
+
+TEST_HOME=$(mktemp -d "${TMPDIR:-/tmp}/scriptlets-home.XXXXXX")
+TEST_FAILURES=$(mktemp "${TMPDIR:-/tmp}/scriptlets-failures.XXXXXX")
+export TEST_FAILURES
+
+cleanup() {
+    rm -f "$TEST_FAILURES"
+    if [ -n "${KEEP_TEST_HOME:-}" ]; then
+        echo "# home kept at $TEST_HOME"
+    else
+        rm -rf "$TEST_HOME"
+    fi
+}
+trap cleanup EXIT
+
+# What a fresh account starts with. `useradd -m` seeds it from /etc/skel, which
+# is where Ubuntu's stock ~/.profile -- the file that puts ~/bin on the PATH --
+# comes from. macOS has no /etc/skel and gives a new account no shell dotfiles
+# at all, which is the case these checks exist to cover.
+if [ -d /etc/skel ]; then
+    cp -R /etc/skel/. "$TEST_HOME"/
+fi
+
+HOME=$TEST_HOME
+export HOME
+
+echo "# repo: $REPO"
+echo "# home: $TEST_HOME"
+echo "# make install"
+make -C "$REPO" install >/dev/null
+
+status=0
+
+for check in "$REPO"/tests/checks/*.sh; do
+    name=${check##*/}
+    name=${name%.sh}
+
+    if [ $# -gt 0 ] && ! printf '%s\n' "$@" | grep -qxF "$name"; then
+        continue
+    fi
+
+    echo "# $name"
+    sh "$check" || status=1
+done
+
+failures=$(wc -l <"$TEST_FAILURES" | tr -d ' ')
+
+if [ "$failures" -gt 0 ] || [ "$status" -ne 0 ]; then
+    echo "# $failures failed"
+    exit 1
+fi
+
+echo "# all checks passed"


### PR DESCRIPTION
## Which user-specific directory lands on the `PATH` on macOS?

None.
A default macOS installation puts no directory below `$HOME` on the `PATH`.
`/usr/libexec/path_helper`, run from `/etc/zprofile` and `/etc/profile`,
builds the `PATH` from `/etc/paths` and `/etc/paths.d` (plus the cryptex entries on Ventura and later),
all system-wide,
and never looks at the home directory.
Neither `~/bin` nor `~/.local/bin` is special there.

The `if it exists` behaviour is Debian's,
not Unix's:
Ubuntu's stock `~/.profile` prepends `~/bin` and then `~/.local/bin`,
which is the only reason the scripts here have ever been found by name.
`rcm/bash_profile` sources `~/.profile`,
but this repository never shipped one —
so on macOS the sourcing failed outright,
and `~/bin` worked only through a hand-written dotfile outside the repository.

## Is it worth moving `~/bin` to `~/.local/bin`?

No.
It gains nothing on macOS, where neither directory is automatic,
and nothing on Ubuntu, where both already are
(`~/.local/bin` ends up in front, being prepended second).
It costs a directory of our own:
`~/.local/bin` is shared with `pipx`, `uv` and `pip install --user`,
whereas `rcdn` is best pointed at a directory only rcm writes to.
`~/bin` stays the install target.

## Changes

- **`rcm/profile`** → `~/.profile`.
  Equivalent to Ubuntu's stock file in order and conditions,
  with one addition: each entry is prepended only when it is not already present,
  so nested login shells (`screen`, `ssh` to localhost) stop stacking duplicates.
- **`rcm/zprofile`** → `~/.zprofile`.
  zsh has been the default shell on macOS since Catalina and never reads `~/.profile`,
  so without this the fix would miss the shell that needs it most.
  `~/.zprofile` rather than `~/.zshenv`, because `path_helper` runs in between and rebuilds the `PATH`.

rcm skips a file the account already has,
so a machine with its own `~/.profile` keeps it until `make force`.

## Tests

`tests/run` installs into a throw-away home directory
seeded the way a stock account is —
on Ubuntu with `.bashrc`, `.profile` and `.bash_logout` from `/etc/skel`,
the three files `useradd -m` copies,
on macOS with nothing at all.
The real home directory is never touched.

- `10-path`: the scripts are on the `PATH` of a login `sh`, `bash` and `zsh`, every script in `rcm/bin` resolves to `~/bin`, and one of them runs.
- `20-install`: every destination rcm lists exists, configuration files are symbolic links, `~/log` is created, installing twice changes nothing.
- `30-preexisting`: an account that came with its own `~/.bash_profile` keeps it, and `make force` is what makes the scripts reachable there.
- `90-force`: `make force` replaces the files rcm skipped, and the scripts are still found — the state a macOS account is in from the start.

`make test-local` runs the suite in place of its previous `ls -lRa`;
`make test` still runs it in a container.
`.github/workflows/test.yaml` runs it on `ubuntu-latest` and `macos-latest`.
Only the macOS job can catch a regression in `rcm/profile` or `rcm/zprofile`:
on Ubuntu the stock `~/.profile` finds the scripts either way.

Verified that the checks fail without the new files
(`zsh` misses `~/bin`; on a home not seeded from `/etc/skel`, `bash` does too)
and pass with them.
The suite is meant to grow — a new file in `tests/checks` is picked up automatically,
`tests/run 10-path` runs one check by name,
and `KEEP_TEST_HOME=1` leaves the home directory behind.

### What the first CI run turned up

The seeding deliberately names the three stock files instead of copying `/etc/skel` wholesale:
the GitHub Actions Ubuntu runner keeps a `~/.bash_profile` there that no stock Ubuntu account has,
and since bash reads `~/.bash_profile` *instead of* `~/.profile`
and rcm leaves an existing file alone,
seeding it put the CI image under test rather than the platform.
That case is worth having, so `30-preexisting` covers it in a home directory of its own.

The other failure was in the check rather than the code:
`a script found on the PATH runs` compared the `git` in the login shell
against the `git` in the process running the checks,
which on macOS are Apple's and Homebrew's respectively.
Both readings now come from the same login shell,
and an empty one fails outright instead of comparing equal.
