### PR TITLE
feat: add `git-ssh-remote` to convert HTTPS GitHub remotes to SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ and they run in name order:
 - `60-zsh-completion`: `~/.zshrc` binds `mise` to the stub, the generated
   completion is *not* loaded at startup, and the first completion loads it and
   rebinds to it.
+- `70-git-ssh-remote`: `git ssh-remote` converts the HTTPS GitHub remotes of a
+  throw-away repository and leaves every other remote alone,
+  through `~/bin` and through the `git sr` alias alike.
 - `90-force`: `mise run force` replaces the files rcm skipped,
   and the scripts are still found afterwards.
   It runs last because it is the one check that rewrites what the others read.
@@ -505,6 +508,26 @@ Create a lightweight tag under `refs/tags/bif/<shortest-unique-prefix>` for ever
 The short prefix is the minimum unique within the bifurcation set, so reruns rename tags (lengthen/shorten) as fork points are added or removed.
 Commits already pointed at by an unrelated branch, tag, or remote ref are skipped to avoid duplicate decoration; annotated tags are dereferenced to their commit, so a `v1.0` release tag at a fork point is recognised.
 `-r` / `--remove` deletes all tags in the namespace and leaves every other tag alone; `-q` / `--quiet` suppresses the summary line.
+
+## git-ssh-remote
+
+Rewrite the HTTPS URLs of a repository's GitHub remotes as their SSH equivalents,
+turning `https://github.com/krlmlr/scriptlets.git` into `git@github.com:krlmlr/scriptlets.git`.
+This is the repair for a clone made with the URL GitHub offers first,
+which asks for a password on every push.
+The `git sr` alias is the short spelling.
+
+Named remotes are converted, all of them when none is named,
+and fetch and push URLs alike — including every URL of a remote that has more than one.
+Remotes that already speak SSH, and HTTPS remotes on other hosts, are left as they are.
+Credentials in the URL (`https://token@github.com/...`) are dropped,
+and so is a port, which says nothing about where SSH listens;
+a missing `.git` suffix is added.
+
+`-n` / `--dry-run` prints what would change and changes nothing;
+`-a` / `--all-hosts` converts HTTPS remotes on any host, not GitHub alone,
+which is what a GitHub Enterprise installation or a GitLab remote needs.
+`-h` shows the help — spelled `--help`, git looks for a man page instead.
 
 ## soffice-macos
 

--- a/rcm/bin/git-ssh-remote
+++ b/rcm/bin/git-ssh-remote
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dry_run=0
+any_host=0
+
+usage() {
+  cat <<'EOF'
+Usage: git ssh-remote [-n|--dry-run] [-a|--all-hosts] [<remote>...]
+
+Rewrite the HTTPS URLs of GitHub remotes as their SSH equivalents:
+
+  https://github.com/krlmlr/scriptlets.git  ->  git@github.com:krlmlr/scriptlets.git
+
+Named remotes are converted, all of them when none is named. Fetch and
+push URLs alike, and every URL of a remote that has more than one.
+Remotes that already speak SSH, and HTTPS remotes on other hosts, are
+left as they are.
+
+Credentials in the URL (https://token@github.com/...) are dropped, and
+so is a port, which says nothing about where SSH listens. A missing
+`.git` suffix is added.
+
+Options:
+  -n, --dry-run    show what would change, change nothing
+  -a, --all-hosts  convert HTTPS remotes on any host, not GitHub alone
+  -h, --help       show this help
+EOF
+}
+
+remotes=
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--dry-run)   dry_run=1 ;;
+    -a|--all-hosts) any_host=1 ;;
+    -h|--help)      usage; exit 0 ;;
+    --)             shift; break ;;
+    -*)             printf 'git-ssh-remote: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    *)              remotes="$remotes$1
+" ;;
+  esac
+  shift
+done
+
+for argument in "$@"; do
+  remotes="$remotes$argument
+"
+done
+
+# Says "fatal: not a git repository" in git's own words, and stops.
+git rev-parse --git-dir >/dev/null
+
+if [ -z "$remotes" ]; then
+  remotes=$(git remote)
+  if [ -z "$remotes" ]; then
+    printf 'git-ssh-remote: this repository has no remotes\n' >&2
+    exit 1
+  fi
+fi
+
+# gist.github.com is a host of its own, and a GitHub Enterprise installation
+# answers to a name nothing here can guess -- that one is what --all-hosts is
+# for.
+is_target_host() {
+  if [ "$any_host" -eq 1 ]; then
+    return 0
+  fi
+
+  case "$1" in
+    github.com|*.github.com) return 0 ;;
+  esac
+
+  return 1
+}
+
+# to_ssh URL -- the scp-like SSH spelling of URL, or nothing and a non-zero
+# status when URL is not an HTTPS URL this command converts.
+to_ssh() {
+  local url=$1 rest host path
+
+  case "$url" in
+    http://*|https://*) rest=${url#*://} ;;
+    *) return 1 ;;
+  esac
+
+  # Without a path there is no repository to name.
+  case "$rest" in
+    */?*) ;;
+    *) return 1 ;;
+  esac
+
+  host=${rest%%/*}
+  path=${rest#*/}
+
+  host=${host##*@}  # user[:password]@ -- a token, most likely
+  host=${host%%:*}  # the HTTPS port, which SSH does not listen on
+  path=${path%/}
+
+  if [ -z "$host" ] || [ -z "$path" ]; then
+    return 1
+  fi
+
+  if ! is_target_host "$host"; then
+    return 1
+  fi
+
+  case "$path" in
+    *.git) ;;
+    *) path=$path.git ;;
+  esac
+
+  printf 'git@%s:%s\n' "$host" "$path"
+}
+
+changed_remotes=0
+
+while IFS= read -r remote; do
+  [ -n "$remote" ] || continue
+
+  if ! git remote | grep -qxF -- "$remote"; then
+    printf 'git-ssh-remote: no such remote: %s\n' "$remote" >&2
+    exit 1
+  fi
+
+  # `git config` rather than `git remote get-url`, which invents a push URL
+  # from the fetch URL where there is none, and would have us write that
+  # invention back.
+  for key in url pushurl; do
+    urls=$(git config --get-all "remote.$remote.$key" || true)
+    [ -n "$urls" ] || continue
+
+    new_urls=
+    changed=0
+
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+
+      if new_url=$(to_ssh "$url") && [ "$new_url" != "$url" ]; then
+        printf '%s\t%s -> %s\n' "$remote" "$url" "$new_url"
+        changed=1
+      else
+        new_url=$url
+      fi
+
+      new_urls="$new_urls$new_url
+"
+    done <<EOF
+$urls
+EOF
+
+    [ "$changed" -eq 1 ] || continue
+    changed_remotes=$((changed_remotes + 1))
+    [ "$dry_run" -eq 0 ] || continue
+
+    # --replace-all for the first URL and --add for any further one: the
+    # remote keeps a URL throughout, which --unset-all would take away for as
+    # long as the rewrite takes.
+    first=1
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+
+      if [ "$first" -eq 1 ]; then
+        git config --replace-all "remote.$remote.$key" "$url"
+        first=0
+      else
+        git config --add "remote.$remote.$key" "$url"
+      fi
+    done <<EOF
+$new_urls
+EOF
+  done
+done <<EOF
+$remotes
+EOF
+
+if [ "$changed_remotes" -eq 0 ]; then
+  printf 'git-ssh-remote: nothing to convert\n' >&2
+elif [ "$dry_run" -eq 1 ]; then
+  printf 'git-ssh-remote: dry run, nothing changed\n' >&2
+fi

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -108,6 +108,7 @@
 	sp = status --porcelain
 	# https://stackoverflow.com/a/5201642/946850
 	sq = !sh -c 'git reset --soft ${1:-main} && git commit --edit -m$(git log --format=%B --reverse HEAD..HEAD@{1})'
+	sr = ssh-remote
 	# hub
 	pr = !sh -c 'hub pull-request "$@"'
 	prm = !sh -c 'hub pull-request -b main "$@"'

--- a/tests/checks/70-git-ssh-remote.sh
+++ b/tests/checks/70-git-ssh-remote.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# `git ssh-remote` converts what it promises to convert and nothing else. The
+# script is exercised through the installed ~/bin and through the `git sr`
+# alias from the installed ~/.gitaliases, so the check covers the wiring as
+# well as the conversion.
+#
+# The repository it works on is a throw-away one below $HOME: `git init`
+# contacts nothing, and neither does rewriting a URL.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+work=$HOME/git-ssh-remote-check
+rm -rf "$work"
+git init -q "$work"
+
+# url_of REMOTE -- what is stored for REMOTE, not what `git remote get-url`
+# shows, which any url.*.insteadOf rewrite would have had a hand in.
+url_of() {
+    git -C "$work" config --get-all "remote.$1.url" | tr '\n' ' ' | sed 's/ $//'
+}
+
+git -C "$work" remote add origin https://github.com/krlmlr/scriptlets.git
+git -C "$work" remote add token https://ghp_secret@github.com/krlmlr/plain
+git -C "$work" remote add ssh git@github.com:krlmlr/ssh.git
+git -C "$work" remote add elsewhere https://gitlab.com/krlmlr/elsewhere.git
+
+assert_ok "git ssh-remote --dry-run succeeds" \
+    git -C "$work" ssh-remote --dry-run
+assert_equal "--dry-run changes nothing" \
+    "https://github.com/krlmlr/scriptlets.git" "$(url_of origin)"
+
+assert_ok "git ssh-remote succeeds" git -C "$work" ssh-remote
+
+assert_equal "an HTTPS GitHub remote becomes an SSH one" \
+    "git@github.com:krlmlr/scriptlets.git" "$(url_of origin)"
+assert_equal "credentials go, and the .git suffix arrives" \
+    "git@github.com:krlmlr/plain.git" "$(url_of token)"
+assert_equal "a remote that already speaks SSH is left alone" \
+    "git@github.com:krlmlr/ssh.git" "$(url_of ssh)"
+assert_equal "a remote on another host is left alone" \
+    "https://gitlab.com/krlmlr/elsewhere.git" "$(url_of elsewhere)"
+
+# --all-hosts is what that other host waits for, and the alias is the spelling
+# that has to work as well as the name does.
+assert_ok "git sr --all-hosts succeeds" \
+    git -C "$work" sr --all-hosts elsewhere
+assert_equal "--all-hosts converts a remote on another host" \
+    "git@gitlab.com:krlmlr/elsewhere.git" "$(url_of elsewhere)"
+
+# Both URLs of a remote that has two, and its push URL, which `git remote
+# get-url` invents where there is none and this command must not write back.
+git -C "$work" remote add many https://github.com/krlmlr/one.git
+git -C "$work" config --add remote.many.url https://github.com/krlmlr/two.git
+git -C "$work" config remote.many.pushurl https://github.com/krlmlr/push.git
+
+assert_ok "git ssh-remote many succeeds" git -C "$work" ssh-remote many
+assert_equal "every URL of a remote is converted" \
+    "git@github.com:krlmlr/one.git git@github.com:krlmlr/two.git" \
+    "$(url_of many)"
+assert_equal "the push URL is converted too" \
+    "git@github.com:krlmlr/push.git" \
+    "$(git -C "$work" config --get-all remote.many.pushurl)"
+assert_equal "no push URL is invented where there was none" \
+    "" "$(git -C "$work" config --get-all remote.origin.pushurl)"
+
+# Running it again has nothing left to do, and says so without failing.
+assert_ok "a second run succeeds" git -C "$work" ssh-remote
+
+if git -C "$work" ssh-remote nosuchremote 2>/dev/null; then
+    fail "an unknown remote is an error"
+else
+    pass "an unknown remote is an error"
+fi
+
+rm -rf "$work"


### PR DESCRIPTION
A clone made with the URL GitHub offers first speaks HTTPS,
and asks for a password on every push.
`git ssh-remote` is the repair:

```console
$ git ssh-remote
origin	https://github.com/krlmlr/scriptlets.git -> git@github.com:krlmlr/scriptlets.git
```

## What it does

- Converts the remotes named, or all of them when none is named,
  and fetch and push URLs alike —
  including every URL of a remote that has more than one.
- Leaves alone what it should:
  remotes that already speak SSH, and HTTPS remotes on other hosts.
- Drops credentials (`https://token@github.com/...`) and a port,
  which says nothing about where SSH listens;
  adds a missing `.git` suffix.
- `-n` / `--dry-run` shows what would change and changes nothing;
  `-a` / `--all-hosts` takes in hosts other than GitHub,
  for a GitHub Enterprise installation or a GitLab remote.

URLs are read with `git config` rather than `git remote get-url`,
which invents a push URL from the fetch URL where there is none —
an invention this command must not write back.
The rewrite uses `--replace-all` for the first URL and `--add` for any further one,
so the remote keeps a URL throughout.

## Changes

- [`rcm/bin/git-ssh-remote`](rcm/bin/git-ssh-remote): the command.
- [`rcm/gitaliases`](rcm/gitaliases): `sr = ssh-remote`, the short spelling.
- [`tests/checks/70-git-ssh-remote.sh`](tests/checks/70-git-ssh-remote.sh):
  a check that works on a throw-away repository below the test home directory,
  covering the conversion, what stays untouched, the multi-URL and push-URL cases,
  and both the `~/bin` and the `git sr` spellings.
  `git init` and rewriting a URL contact nothing, so the check stays offline.
- [`README.md`](README.md): the tool and the new check.

`tests/run` passes on Ubuntu (zsh not installed there, so its two checks skip as before).


---
_Generated by [Claude Code](https://claude.ai/code/session_0132cofwycqoGYky7k1wQ3Wt)_