### PR TITLE
fix: source `rigenv` from `~/.profile` only, and guard it

### DIFF
--- a/rcm/bash_profile
+++ b/rcm/bash_profile
@@ -6,4 +6,9 @@ keychain ~/.ssh/id_rsa
 
 . ~/.autoscreen
 
+# rig appends this line to every startup file it knows about,
+# and only ever checks that the line is there:
+# ~/.profile sources rigenv once, for every shell, so this copy stays off.
+if false; then
 . "$HOME/.local/bin/rigenv"
+fi

--- a/rcm/bashrc
+++ b/rcm/bashrc
@@ -211,4 +211,9 @@ if [ -d /opt/homebrew ]; then
   export PATH=/opt/homebrew/bin:$PATH
 fi
 
+# rig appends this line to every startup file it knows about,
+# and only ever checks that the line is there:
+# ~/.profile sources rigenv once, for every shell, so this copy stays off.
+if false; then
 . "$HOME/.local/bin/rigenv"
+fi

--- a/rcm/profile
+++ b/rcm/profile
@@ -40,4 +40,16 @@ if [ -d "$HOME/.local/bin" ]; then
     esac
 fi
 
+# rig appends this line to every startup file it knows about,
+# and only ever checks that the line is there.
+# This is the one copy that runs;
+# the ones in ~/.bashrc, ~/.bash_profile, ~/.zshrc and ~/.zprofile
+# are parked behind `if false`.
+#
+# The guard is what makes a machine without rig survive:
+# `.` on a missing file ends a POSIX sh outright,
+# taking the rest of this file, and the PATH set above, with it.
+# The line itself is left verbatim and unindented, for rig to find.
+if [ -f "$HOME/.local/bin/rigenv" ]; then
 . "$HOME/.local/bin/rigenv"
+fi

--- a/rcm/zprofile
+++ b/rcm/zprofile
@@ -16,4 +16,9 @@ zsh_startup_mark zprofile
 
 emulate sh -c '. "$HOME/.profile"'
 
+# rig appends this line to every startup file it knows about,
+# and only ever checks that the line is there:
+# ~/.profile sources rigenv once, for every shell, so this copy stays off.
+if false; then
 . "$HOME/.local/bin/rigenv"
+fi

--- a/rcm/zshrc
+++ b/rcm/zshrc
@@ -35,4 +35,9 @@ if (( $+commands[mise] && $+functions[compdef] )); then
     compdef _mise_lazy mise
 fi
 
+# rig appends this line to every startup file it knows about,
+# and only ever checks that the line is there:
+# ~/.profile sources rigenv once, for every shell, so this copy stays off.
+if false; then
 . "$HOME/.local/bin/rigenv"
+fi


### PR DESCRIPTION
The previous commit, `chore: Installed by rig`, appended
`. "$HOME/.local/bin/rigenv"` to all five startup files rig knows about:
`~/.profile`, `~/.bash_profile`, `~/.bashrc`, `~/.zprofile` and `~/.zshrc`.

rig only checks that the line is *present*,
so the four copies outside `~/.profile` are now wrapped in `if false; then ... fi`,
leaving `~/.profile` — where the `PATH` is assembled for every shell — as the single place that actually sources rigenv.
Each disabled copy carries a two-line comment saying why it is off.

The surviving invocation is also guarded with `[ -f ... ]`.
`.` on a missing file ends a POSIX sh outright,
so on a machine without rig the unguarded line killed `~/.profile` halfway through
and took the `PATH` set just above it with it.
The line itself is left verbatim and unindented inside both guards, so rig's check still matches it.

## Verification

`tests/run` was already failing on `main` after the rig commit:

```
NOT OK   sh: ~/bin is still on the PATH after mise run force
         PATH=
NOT OK   zsh: ~/bin is still on the PATH after mise run force
         PATH=
```

bash only warns and carries on, which is why the failure showed up for `sh` and `zsh` alone.
With this change the full suite passes again (`# all checks passed`),
and `sh -n` / `bash -n` / `zsh -n` parse each edited file.

---
_Generated by [Claude Code](https://claude.ai/code/session_013eHDtPRGD4zQ4B21UMjPyw)_