### PR TITLE
fix: restore the bare `mise run` menu, and quieten the zsh startup marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ bash and fish are on their own — `mise completion bash` or `fish`.
   hands `~/.profile` to zsh, which would not read it otherwise.
 - [`rcm/zshrc`](rcm/zshrc): installed as `~/.zshrc`,
   starts the completion system and registers mise's completion lazily.
+- [`rcm/zshenv`](rcm/zshenv): installed as `~/.zshenv`, read by every zsh
+  before anything else.
+  It loads the startup profiler where that exists, and defines a no-op
+  `zsh_startup_mark` where it does not, which is what keeps the marks in the
+  other two files quiet on a machine that has never seen the profiler.
 - [`rcm/log/dummy`](rcm/log): placeholder that brings `~/log` into existence.
   Keep the name dotless — rcm skips names starting with a dot.
 - [`mise-tasks/`](mise-tasks): one script per task.
@@ -361,9 +366,9 @@ and they run in name order:
   It works on a copy, because importing *moves* files into the repository.
 - `50-makefile`: the `Makefile` fallback agrees with the tasks it stands in
   for, and the targets it does not implement say so instead of pretending.
-- `60-zsh-completion`: `~/.zshrc` binds `mise` to the stub, the generated
-  completion is *not* loaded at startup, and the first completion loads it and
-  rebinds to it.
+- `60-zsh-startup`: a zsh startup says nothing at all, and `~/.zshrc` binds
+  `mise` to the stub — the generated completion is *not* loaded at startup, and
+  the first completion loads it and rebinds to it.
 - `70-git-ssh-remote`: `git ssh-remote` converts the HTTPS GitHub remotes of a
   throw-away repository and leaves every other remote alone,
   through `~/bin` and through the `git sr` alias alike.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Licensed under [GPL v3](http://www.gnu.org/copyleft/gpl.html).
 
 To install all scripts to `~/bin` (by creating symbolic links),
 install [rcm](https://github.com/thoughtbot/rcm),
-clone the project and run `make` — or `mise run`,
+clone the project and run `make` — or `mise run install`,
 if you have [mise](https://mise.jdx.dev).
 rcm is the only thing this needs; mise is optional.
 Or run the [`bootstrap`](bootstrap) script:
@@ -29,7 +29,7 @@ reachable through [mise](https://mise.jdx.dev) or through `make`:
 
 | Task | `make` | |
 | --- | --- | --- |
-| `mise run`, `mise run install` | `make` | link every file into the home directory |
+| `mise run install` | `make` | link every file into the home directory |
 | `mise run force` | `make force` | link every file, replacing ones that already exist |
 | `mise run check` | `make check` | list the mapping without touching the filesystem |
 | `mise run uninstall` | `make uninstall` | remove every symbolic link rcm owns |
@@ -52,7 +52,9 @@ construction cannot: that no task was added without a target to reach it by.
 
 What mise adds, if you have it:
 `mise tasks` lists the tasks with their descriptions,
-`mise run` with no task opens a picker on a terminal,
+`mise run` with no task at all opens a picker on a terminal —
+no task is aliased to `default`, so a bare `mise run` asks rather than installs,
+and [`tests/checks/15-tasks.sh`](tests/checks/15-tasks.sh) keeps it that way,
 `mise run import` is the one task `make` cannot offer,
 and the completion described [below](#picking-the-file).
 Its one obligation is trust —
@@ -348,6 +350,7 @@ and they run in name order:
 
 - `10-path`: the scripts are on the `PATH` of a login shell, in every shell an
   account may log in with, and they run.
+- `15-tasks`: a bare `mise run` offers the task list instead of running one.
 - `20-install`: every destination rcm lists exists, configuration files are
   symbolic links, and installing twice changes nothing.
 - `30-preexisting`: an account that came with its own `~/.bash_profile` keeps it,
@@ -390,7 +393,7 @@ The previous layout is preserved on the
 | `home/bin/h` | `rcm/bin/h` — `bin` is in `UNDOTTED`, so the name is kept |
 | `personalized/<USER>/gitconfig` | `rcm/tag-<USER>/scriptlets/gitconfig` |
 | `home/dot-finicky.js`, `home/dot-toprc` | `rcm/tag-macos/finicky.js`, `rcm/tag-linux/toprc` |
-| `make` | `make` — unchanged, or `mise run`, which runs the same scripts |
+| `make` | `make` — unchanged, or `mise run install`, which runs the same script |
 | `make build` (regenerate the installers) | — nothing to regenerate |
 | `make run-force-install` | `mise run force` |
 | — | `mise run uninstall`, `mise run check`, `mise run import` |

--- a/mise-tasks/install
+++ b/mise-tasks/install
@@ -1,6 +1,5 @@
 #!/bin/sh
 #MISE description="Link every file into the home directory"
-#MISE alias="default"
 set -eu
 . "$(dirname -- "$0")/lib.sh"
 

--- a/rcm/zshenv
+++ b/rcm/zshenv
@@ -1,5 +1,12 @@
 # >>> zsh startup profiling (new-macbook-2026) >>>
 [[ -r ~/git/new-macbook-2026/scripts/zsh-startup-profile.zsh ]] && source ~/git/new-macbook-2026/scripts/zsh-startup-profile.zsh
 export ZSH_STARTUP_MARKS=1
+# The marks here, in ~/.zprofile and in ~/.zshrc call a function that only the
+# profiler above defines, and that profiler lives in a repository which is only
+# on the machine it was written for. Everywhere else, every zsh start said
+# `command not found: zsh_startup_mark`, once per startup file it read.
+# ~/.zshenv is read first by every zsh there is, so one no-op here covers all
+# three, and the real function still wins wherever it is installed.
+(( $+functions[zsh_startup_mark] )) || zsh_startup_mark() { : }
 zsh_startup_mark zshenv
 # <<< zsh startup profiling <<<

--- a/tests/checks/15-tasks.sh
+++ b/tests/checks/15-tasks.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# `mise run` with no task offers the task list -- on a terminal, a picker --
+# rather than running something.
+#
+# It is one line away from not doing that: an `#MISE alias="default"` on any
+# task makes a bare `mise run` run that task instead, which is a surprise where
+# a menu was expected, and a surprise that writes to the home directory.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+output=$(mise -C "$REPO" run </dev/null 2>&1 || true)
+
+if mise -C "$REPO" run </dev/null >/dev/null 2>&1; then
+    fail "a bare mise run does not run a task" "it succeeded, so something ran"
+else
+    pass "a bare mise run does not run a task"
+fi
+
+missing=
+for name in install import check test; do
+    case "$output" in
+    *"$name"*) ;;
+    *) missing="$missing $name" ;;
+    esac
+done
+
+if [ -z "$missing" ]; then
+    pass "a bare mise run offers the tasks to choose from"
+else
+    fail "a bare mise run offers the tasks to choose from" \
+        "not listed:$missing
+$output"
+fi

--- a/tests/checks/60-zsh-startup.sh
+++ b/tests/checks/60-zsh-startup.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
-# ~/.zshrc registers mise's completion lazily: a stub stands in until the first
-# Tab, which then loads the generated completion and hands over. Both halves are
-# checked -- a stub that never loads the real thing completes nothing, and an
+# The zsh startup files: quiet, and lazy about mise's completion.
+#
+# Quiet, because a line that only works on one machine is easy to add and hard
+# to notice -- the profiling marks called a function that only the author's
+# profiler defines, so every zsh start elsewhere said `command not found`, once
+# per startup file.
+#
+# Lazy, because ~/.zshrc registers mise's completion through a stub that stands
+# in until the first Tab and then loads the generated completion. Both halves
+# are checked: a stub that never loads the real thing completes nothing, and an
 # eager load costs a `usage` run at every shell start, which is the thing being
 # avoided.
 
@@ -28,6 +35,17 @@ probe() {
 
 assert_equal "~/.zshrc is installed" \
     "$REPO/rcm/zshrc" "$(readlink "$HOME/.zshrc" 2>/dev/null)"
+
+# Interactive *and* login, so that all three files are read. Only complaints
+# that name a file in this home directory count: a system-wide zshrc with
+# opinions of its own is not ours to fix.
+noise=$(zsh -ilc true </dev/null 2>&1 >/dev/null | grep -F "$HOME" || true)
+
+if [ -z "$noise" ]; then
+    pass "a zsh startup says nothing"
+else
+    fail "a zsh startup says nothing" "$noise"
+fi
 
 assert_equal "zsh binds mise to the lazy stub" \
     "_mise_lazy" "$(probe 'print "probe=${_comps[mise]}"')"


### PR DESCRIPTION
Two fixes, both for things visible on `main` right now.

## A bare `mise run` installs instead of offering the menu

#25 was squash-merged one commit early, so the fix for this did not come with it.
`main` is inconsistent as it stands: the README says `mise run install`
and describes the picker, while `mise-tasks/install` still carries
`#MISE alias="default"` — which is exactly what `mise run` with no task looks for.

The alias is removed here, restoring what the README already claims:

- `mise run` → the fuzzy picker on a terminal; off a terminal it prints the task list and exits non-zero, having run nothing
- `mise run install` → installs
- `make` → installs, unchanged

[`tests/checks/15-tasks.sh`](tests/checks/15-tasks.sh) is the guard —
one `#MISE alias` line is all it takes to undo,
so it asserts that a bare `mise run` runs nothing and lists the tasks instead.
Verified non-vacuous by putting the alias back and watching both assertions fail.

## Every zsh start says `command not found: zsh_startup_mark`

`zsh_startup_mark` is defined by the profiler in `new-macbook-2026`,
which is on one machine.
Everywhere else, the marks added to `~/.zshenv`, `~/.zprofile` and `~/.zshrc`
produce one `command not found` per startup file, on every single zsh start:

```
$ zsh -ilc true
~/.zshenv:4: command not found: zsh_startup_mark
~/.zshrc:7: command not found: zsh_startup_mark
```

That is from this container, which is a machine like any other that does not have the profiler.

`~/.zshenv` is read first by every zsh there is, so one no-op definition there covers all three files,
and the real function still wins wherever the profiler is installed
(verified both ways: silent without it, `MARK zshenv` / `MARK zprofile` / `MARK zshrc` with it).

The suite could not have caught this, which is its own small bug:
`60-zsh-completion.sh` dropped stderr, because a system-wide zshrc running its own `compinit`
is noisy about insecure directories and none of that is ours to fix.
It is now `60-zsh-startup.sh` and asserts that a zsh startup says nothing that names a file
in the home directory under test — system opinions still ignored, ours no longer.
Also verified non-vacuous.

Both platforms are exercised by the existing matrix; the zsh checks run on macOS too.


---
_Generated by [Claude Code](https://claude.ai/code/session_011KvRXJheX78TEY9rXu4yMx)_