### PR TITLE
feat: measure zsh startup on every shell, and document how to turn it off

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,14 @@ bash and fish are on their own — `mise completion bash` or `fish`.
   starts the completion system and registers mise's completion lazily.
 - [`rcm/zshenv`](rcm/zshenv): installed as `~/.zshenv`, read by every zsh
   before anything else.
-  It loads the startup profiler where that exists, and defines a no-op
-  `zsh_startup_mark` where it does not, which is what keeps the marks in the
-  other two files quiet on a machine that has never seen the profiler.
+  It loads the [startup profiler](#zsh-startup-profiling), and defines a no-op
+  `zsh_startup_mark` where the profiler declines to,
+  which is what keeps the marks in the other two files quiet
+  when profiling is switched off — or when this file arrived without it.
+- [`rcm/zsh-startup-profile.zsh`](rcm/zsh-startup-profile.zsh): installed as
+  `~/.zsh-startup-profile.zsh` and sourced from the first line of `~/.zshenv`,
+  which is what lets it time the whole rc chain.
+  Described [below](#zsh-startup-profiling).
 - [`rcm/log/dummy`](rcm/log): placeholder that brings `~/log` into existence.
   Keep the name dotless — rcm skips names starting with a dot.
 - [`mise-tasks/`](mise-tasks): one script per task.
@@ -287,6 +292,9 @@ The scripts themselves assume a GNU userland under Homebrew's `g` names:
 `n` and `bkg` need `terminal-notifier`, and are installed on macOS only;
 `rpt` needs `inotifywait` and `unbuffer`;
 `git-mmv` needs `mmv`; `imgdiff` needs ImageMagick.
+`zsh-startup-bench` needs `hyperfine` for its benchmark mode alone
+(`brew install hyperfine`, `apt install hyperfine`);
+reading the log and the `zprof` breakdown needs nothing but zsh.
 
 Putting `~/bin` on the `PATH` is not among the things left to you:
 [`rcm/profile`](rcm/profile) and [`rcm/zprofile`](rcm/zprofile) do it,
@@ -302,6 +310,8 @@ these land in the home directory:
 | [`profile`](rcm/profile), [`zprofile`](rcm/zprofile) | `~/.profile`, `~/.zprofile` | login shells of any kind: `~/bin` and `~/.local/bin` on the `PATH` |
 | [`bashrc`](rcm/bashrc), [`bash_profile`](rcm/bash_profile), [`bash_aliases`](rcm/bash_aliases) | `~/.bashrc`, `~/.bash_profile`, `~/.bash_aliases` | interactive bash: prompt, history, aliases |
 | [`tag-macos/bash_aliases_os`](rcm/tag-macos/bash_aliases_os), [`tag-linux/bash_aliases_os`](rcm/tag-linux/bash_aliases_os) | `~/.bash_aliases_os` | the aliases, completions and bindings of one platform, sourced from `~/.bash_aliases` |
+| [`zshenv`](rcm/zshenv), [`zshrc`](rcm/zshrc) | `~/.zshenv`, `~/.zshrc` | zsh: the profiler for every shell, completion and history for the interactive ones |
+| [`zsh-startup-profile.zsh`](rcm/zsh-startup-profile.zsh) | `~/.zsh-startup-profile.zsh` | times every interactive zsh startup — [below](#zsh-startup-profiling) |
 | [`autoscreen`](rcm/autoscreen) | `~/.autoscreen` | drop into `screen` automatically on an interactive SSH login |
 | [`gitconfig`](rcm/gitconfig), [`gitaliases`](rcm/gitaliases) | `~/.gitconfig`, `~/.gitaliases` | Git settings and aliases; pulls in several optional `~/.gitconfig.*` includes |
 | [`gitignore`](rcm/gitignore) | `~/.gitignore` | global excludes, wired up via `core.excludesfile` |
@@ -317,9 +327,108 @@ these land in the home directory:
 | [`git/R/`](rcm/git/R) | `~/git/R/` | CMake and build helpers for working on the R sources in CLion |
 
 Several of these source files that this repository does *not* ship —
-`~/.bash_secrets`, `~/git/bash-git-prompt`, `~/git/complete-alias` —
+`~/git/bash-git-prompt`, `~/git/complete-alias` —
 without guarding for their absence,
 so a fresh shell reports errors until they exist or the lines are removed.
+`~/.bash_secrets` used to be among them,
+and is now sourced only if it is there:
+it is the one of the three that a machine may legitimately never need,
+and the error was reaching zsh as well,
+which reads `~/.bash_aliases` through `~/.zshrc`.
+
+## zsh startup profiling
+
+Every interactive zsh times its own startup,
+appends one line to `~/.local/state/zsh-startup.log`,
+and says what it cost before the first prompt:
+
+```
+zsh startup 61 ms
+     0.4 ms  zshenv           (+0.4)
+     6.1 ms  zprofile         (+5.7)
+     8.2 ms  zshrc            (+2.1)
+    61.0 ms  first prompt     (+52.8)
+```
+
+Startup time is a number that only ever grows,
+one `eval "$(… init -)"` at a time,
+and it grows below the threshold anyone would notice on a single day.
+Measuring it continuously, from real shells,
+is the cheapest way to catch the line that cost 200 ms
+on the day it was added rather than a year later.
+
+[`rcm/zsh-startup-profile.zsh`](rcm/zsh-startup-profile.zsh) is the whole
+mechanism, and [`rcm/zshenv`](rcm/zshenv) sources it on its first line —
+`~/.zshenv` is the first file every zsh reads,
+so nothing that runs later could see the time the earlier files took.
+The last line of each of the three startup files calls `zsh_startup_mark`,
+which appends to an array;
+one `precmd` hook then prints the timeline before the first prompt
+and unhooks itself.
+There are no forks in any of it,
+and a non-interactive shell — every script, every `zsh -c` —
+returns after two builtin statements.
+
+Each line is what that file had cost by the time it was *done*,
+and the `(+…)` is that file's own share.
+The last gap is the one no benchmark can see:
+`first prompt` minus `zshrc` is everything the terminal itself does
+after the configuration has finished —
+shell integration, session restore, the terminal's own rc hooks.
+
+`zsh -i -c 'exit 0'` never reaches a prompt,
+so benchmark runs are absent from the log by construction.
+
+### Turning it off
+
+The knobs are environment variables,
+and the place to set them on one machine is `~/scriptlets/zsh-startup`,
+which the profiler sources before it does anything else.
+That file is not shipped here —
+it is yours, per machine, like `~/.bash_secrets` —
+and it joins the `~/scriptlets/` files
+that [per-user overrides](#per-user-overrides) already describes.
+Anything exported before zsh starts works too,
+which is what makes `ZSH_STARTUP_PROFILE=0 zsh` a one-shot escape.
+
+| Set | Effect |
+| --- | --- |
+| `ZSH_STARTUP_BUDGET_MS=500` | say nothing unless a startup exceeds the budget; keep recording |
+| `ZSH_STARTUP_BUDGET_MS=` | say nothing, ever; keep recording |
+| `ZSH_STARTUP_MARKS=` | keep the one-line notice, drop the timeline below it |
+| `ZSH_STARTUP_LOG=` | stop recording; keep the notice |
+| `ZSH_STARTUP_PROFILE=0` | off entirely: nothing is loaded, nothing is timed, nothing is written |
+
+So the usual progression is
+`ZSH_STARTUP_BUDGET_MS=500` once the number is boring —
+the log keeps filling, and only a regression speaks up —
+and `ZSH_STARTUP_PROFILE=0` when even that is unwelcome.
+The timeline is only ever printed under the notice it breaks down,
+so silencing the notice silences both.
+
+Off is off at the source: with `ZSH_STARTUP_PROFILE=0`
+the profiler returns before it loads a module or defines a function,
+and the no-op `zsh_startup_mark` in `~/.zshenv` absorbs the three marks
+left behind in the startup files.
+Removing the profiler for good is a matter of deleting
+`rcm/zsh-startup-profile.zsh` and the `# >>> zsh startup profiling >>>` blocks —
+run `mise run uninstall` *before* deleting the file,
+or the symbolic link in `$HOME` is left dangling.
+
+The log is append-only and never rotated —
+one short line per shell, four tab-separated fields.
+Trim it when it gets long:
+
+```sh
+tail -n 5000 ~/.local/state/zsh-startup.log > ~/.local/state/zsh-startup.log.tmp &&
+  mv ~/.local/state/zsh-startup.log.tmp ~/.local/state/zsh-startup.log
+```
+
+### Reading the numbers
+
+[`zsh-startup-bench`](rcm/bin/zsh-startup-bench) is the other half,
+and it answers three different questions —
+see [below](#zsh-startup-bench).
 
 ## Tests
 
@@ -366,9 +475,13 @@ and they run in name order:
   It works on a copy, because importing *moves* files into the repository.
 - `50-makefile`: the `Makefile` fallback agrees with the tasks it stands in
   for, and the targets it does not implement say so instead of pretending.
-- `60-zsh-startup`: a zsh startup says nothing at all, and `~/.zshrc` binds
+- `60-zsh-startup`: a zsh startup complains about nothing, and `~/.zshrc` binds
   `mise` to the stub — the generated completion is *not* loaded at startup, and
   the first completion loads it and rebinds to it.
+- `65-zsh-startup-profile`: a shell that reaches a prompt is timed, recorded
+  once and broken down by startup file; one that does not — a script, a
+  `zsh -c`, a benchmark run — is left alone; and every documented way of
+  [turning the profiling off](#turning-it-off) turns it off.
 - `70-git-ssh-remote`: `git ssh-remote` converts the HTTPS GitHub remotes of a
   throw-away repository and leaves every other remote alone,
   through `~/bin` and through the `git sr` alias alike.
@@ -478,6 +591,46 @@ Files are discovered with `ag`.
 
 Run `air format` on a single file if the containing Git repository has an `air.toml` file.
 Useful as a formatter in the RStudio IDE.
+
+## zsh-startup-bench
+
+Three views of one question — what does starting a shell cost? —
+on top of the [startup profiling](#zsh-startup-profiling)
+that every interactive zsh does anyway.
+
+```sh
+zsh-startup-bench           # hyperfine: this configuration against the bare floor
+zsh-startup-bench --zprof   # per-function breakdown of a single startup
+zsh-startup-bench --log     # summarise the continuous log
+```
+
+`--log` is the number to trust:
+it comes from real shells on this machine —
+count, min, median, p90, max and mean,
+broken down by terminal and by login versus interactive.
+It is the only view that reflects a cold cache, a busy laptop,
+or a terminal that starts a login shell where you expected an interactive one.
+
+The benchmark compares three shells:
+a login shell (what a new tab starts),
+a plain interactive one (a `zsh` inside an existing tab),
+and `zsh -f`, the same binary with no rc files at all.
+The floor is what makes the rest legible —
+40 ms of zsh plus 600 ms of our own configuration
+is a different verdict from 640 ms of zsh.
+The gap between the first two is a finding in itself:
+only login shells read `/etc/zprofile` and `~/.zprofile`,
+which on macOS fork `path_helper` and `brew shellenv`.
+This mode is the one that needs `hyperfine`.
+
+`--zprof` ranks the functions of a single startup.
+Read the ranking, not the total:
+loading `zprof` instruments every function call and inflates what it measures,
+and it sees function calls *only* —
+a top-level `eval`, a bare `source` or a fork never appears in the table.
+
+`--runs` and `--top` set the benchmark's run count and the length of the
+`zprof` table; `-h` prints the commentary above in full.
 
 ## git-mmv
 

--- a/rcm/bash_aliases
+++ b/rcm/bash_aliases
@@ -32,4 +32,10 @@ if [ -f ~/.bash_aliases_os ]; then
   . ~/.bash_aliases_os
 fi
 
-. ~/.bash_secrets
+# Machine-local secrets, never in this repository. Guarded, because the file is
+# absent on any machine that has not needed one yet, and an unguarded `.` made
+# every interactive shell there open with a `no such file or directory` --
+# including the zsh ones, which read this file through ~/.zshrc.
+if [ -f ~/.bash_secrets ]; then
+  . ~/.bash_secrets
+fi

--- a/rcm/bin/zsh-startup-bench
+++ b/rcm/bin/zsh-startup-bench
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Measure zsh startup: benchmark it, break it down, or read the production log.
+#
+#   zsh-startup-bench           # hyperfine: this config vs. the bare floor
+#   zsh-startup-bench --zprof   # per-function breakdown of one startup
+#   zsh-startup-bench --log     # summarise the continuous log
+#
+# Three views of the same question, and they answer different halves of it:
+#
+#   --log    what startup actually costs on this machine, from real shells.
+#            The number to trust, and the only one that reflects a cold cache,
+#            a busy laptop, or a terminal that spawns a login shell.
+#            Fed by ~/.zsh-startup-profile.zsh; nothing to run first.
+#   (bench)  a controlled A/B of three shells: login (what a new terminal tab
+#            starts), plain interactive (a `zsh` launched inside an existing
+#            tab), and `zsh -f` -- the same binary with no rc files at all.
+#            The floor is what makes the numbers legible: 40 ms of zsh plus
+#            600 ms of our own config is a very different verdict from 640 ms
+#            of zsh. The login/interactive gap is its own finding: only login
+#            shells read /etc/zprofile and ~/.zprofile, which on macOS fork
+#            path_helper and `brew shellenv`. A tab paying far more than a
+#            nested shell means the cost is in those two files.
+#   --zprof  where the time goes, per function, for one startup. Loading zprof
+#            instruments every function call, so its absolute numbers run high
+#            -- read the ranking, not the total.
+#
+# Benchmarks use `zsh -i -c 'exit 0'`, which loads the full rc chain but never
+# reaches a prompt, so these runs are absent from the production log.
+#
+# The `0` is not decoration. A bare `exit` exits with the status of the last
+# command the shell ran, which here is the last statement of the rc chain --
+# and on stock macOS that is /etc/zshrc's
+#
+#   [ -r "/etc/zshrc_$TERM_PROGRAM" ] && . "/etc/zshrc_$TERM_PROGRAM"
+#
+# false in any terminal Apple does not ship a file for. A healthy shell then
+# reports 1 and hyperfine aborts the run. `exit 0` measures the same startup
+# and says so unambiguously.
+#
+# Requires hyperfine for the benchmark mode:
+#   brew install hyperfine   /   apt install hyperfine
+# (--zprof and --log need nothing beyond zsh.)
+#
+# Reading the output, and turning the profiling off:
+# the "zsh startup profiling" section of the scriptlets README.
+
+set -euo pipefail
+
+MODE=bench
+RUNS=20
+TOP=25
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --zprof)   MODE=zprof; shift ;;
+    --log)     MODE=log; shift ;;
+    --runs)    RUNS="${2:?--runs needs a number}"; shift 2 ;;
+    --top)     TOP="${2:?--top needs a number}"; shift 2 ;;
+    -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
+    *)         echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v zsh >/dev/null || { echo "zsh not found on PATH" >&2; exit 1; }
+
+LOG="${ZSH_STARTUP_LOG:-${XDG_STATE_HOME:-$HOME/.local/state}/zsh-startup.log}"
+
+case "$MODE" in
+
+bench)
+  command -v hyperfine >/dev/null || {
+    echo "hyperfine not found on PATH -- brew install hyperfine / apt install hyperfine" >&2
+    exit 1
+  }
+  # -N runs each command directly instead of through an intermediate /bin/sh.
+  # These shells start in single-digit milliseconds, which is the range where
+  # hyperfine warns it cannot calibrate its own wrapper away; without it the
+  # wrapper is a sizeable fraction of what gets reported.
+  hyperfine \
+    -N \
+    --warmup 3 \
+    --runs "$RUNS" \
+    --command-name "login        (new tab)" "zsh -l -i -c 'exit 0'" \
+    --command-name "interactive  (nested zsh)" "zsh -i -c 'exit 0'" \
+    --command-name "bare floor   (no rc files)" "zsh -f -i -c 'exit 0'"
+  ;;
+
+zprof)
+  # The module has to be loaded before the rc files run, which is what the env
+  # var does inside the fragment; `zprof` then reports without needing a prompt.
+  ZSH_STARTUP_ZPROF=1 zsh -i -c zprof | head -n "$((TOP + 3))"
+  echo
+  echo "Ranking, not absolute times: zprof's own instrumentation inflates the total."
+  echo
+  echo "zprof sees FUNCTION CALLS only. Top-level code in the rc files -- a"
+  echo "\`brew shellenv\` eval, a bare \`source\`, any fork -- never appears here, so"
+  echo "a short table means few functions ran, not that startup is cheap. --log"
+  echo "and the floor benchmark hold the wall-clock truth."
+  echo
+  echo "If this prints nothing at all, ~/.zshenv is not sourcing"
+  echo "~/.zsh-startup-profile.zsh -- run \`mise run install\` in the scriptlets"
+  echo "checkout, and check that ZSH_STARTUP_PROFILE is not switched off."
+  ;;
+
+log)
+  [ -s "$LOG" ] || {
+    echo "no startup log at $LOG" >&2
+    echo "Interactive shells write it once ~/.zshenv sources" >&2
+    echo "~/.zsh-startup-profile.zsh -- open a new terminal, then re-run." >&2
+    exit 1
+  }
+
+  echo "log: $LOG"
+  echo
+
+  cut -f2 "$LOG" | sort -n | awk '
+    { ms[NR] = $1; total += $1 }
+    END {
+      mid = int((NR + 1) / 2)
+      p90 = int(NR * 0.9); if (p90 < 1) p90 = 1
+      printf "shells   %d\n", NR
+      printf "min      %d ms\n", ms[1]
+      printf "median   %d ms\n", ms[mid]
+      printf "p90      %d ms\n", ms[p90]
+      printf "max      %d ms\n", ms[NR]
+      printf "mean     %d ms\n", total / NR
+    }'
+
+  echo
+  echo "by terminal:"
+  awk -F'\t' '
+    { n[$3 " " $4]++; sum[$3 " " $4] += $2 }
+    END { for (k in n) printf "  %-28s %5d ms mean over %d\n", k, sum[k] / n[k], n[k] }' \
+    "$LOG" | sort
+
+  echo
+  echo "last 5:"
+  tail -n 5 "$LOG" | awk -F'\t' '{ printf "  %s  %5d ms  %s %s\n", $1, $2, $3, $4 }'
+
+  echo
+  echo "The log is append-only and never rotated; trim it when it gets long:"
+  echo "  tail -n 5000 \"$LOG\" > \"$LOG.tmp\" && mv \"$LOG.tmp\" \"$LOG\""
+  ;;
+
+esac

--- a/rcm/zprofile
+++ b/rcm/zprofile
@@ -1,7 +1,3 @@
-# >>> zsh startup profiling >>>
-zsh_startup_mark zprofile
-# <<< zsh startup profiling <<<
-
 # ~/.zprofile: read by login zsh shells.
 #
 # zsh has been the default shell on macOS since Catalina,
@@ -22,3 +18,9 @@ emulate sh -c '. "$HOME/.profile"'
 if false; then
 . "$HOME/.local/bin/rigenv"
 fi
+
+# Last line on purpose: the mark records when this file was *done*, so the
+# timeline printed at the first prompt attributes the time to the right file.
+# >>> zsh startup profiling >>>
+zsh_startup_mark zprofile
+# <<< zsh startup profiling <<<

--- a/rcm/zsh-startup-profile.zsh
+++ b/rcm/zsh-startup-profile.zsh
@@ -1,0 +1,140 @@
+#
+# zsh startup instrumentation -- installed as ~/.zsh-startup-profile.zsh,
+# sourced from the first line of ~/.zshenv, never executed.
+#
+# Two jobs, one file:
+#
+#   1. ALWAYS ON -- time every interactive startup and append one line to the
+#      log. The number worth having is the one from real shells on a real
+#      machine, over weeks, not the one from a clean-room benchmark run once.
+#   2. ON REQUEST -- load zsh/zprof so a single startup can be broken down per
+#      function. That one is opt-in because zprof instruments every function
+#      call and distorts the very number being measured.
+#
+# ~/.zshenv is the first file every zsh reads, which is why the fragment is
+# sourced from there: the measurement then covers the whole rc chain
+# (.zshenv -> .zprofile -> .zshrc), not just the tail of it.
+#
+# Non-interactive shells (every script, every `zsh -c`) leave after two builtin
+# statements. Interactive ones pay one precmd hook that runs once, before the
+# first prompt, and unhooks itself.
+#
+# `zsh -i -c 'exit 0'` never reaches a prompt, so benchmark runs do NOT write to
+# the log -- benchmark noise stays out of the production record by construction.
+#
+# Reading the numbers, and turning any of this off:
+# the "zsh startup profiling" section of the README.
+#
+# Knobs, all optional, all read from the environment -- and from
+# ~/scriptlets/zsh-startup, which is sourced first and is the place to set them
+# on one machine without touching the dotfiles every machine shares:
+#
+#   ZSH_STARTUP_PROFILE     0 or empty: do nothing at all. The off switch;
+#                           anything else, including unset, leaves it on.
+#   ZSH_STARTUP_LOG         where to append; empty disables logging entirely
+#                           (default $XDG_STATE_HOME/zsh-startup.log, i.e.
+#                           ~/.local/state/zsh-startup.log)
+#   ZSH_STARTUP_BUDGET_MS   print a one-line notice when startup exceeds this
+#                           many milliseconds. Default 0 -- every startup
+#                           exceeds 0, so every startup reports itself, which
+#                           is what you want while the config is being built up
+#                           install by install. Set it to a real budget (500)
+#                           once the number is boring and only regressions
+#                           should speak up; set it empty to say nothing.
+#   ZSH_STARTUP_ZPROF       non-empty: load zsh/zprof and print the breakdown
+#                           before the first prompt
+#   ZSH_STARTUP_MARKS       non-empty: break the notice above down into the
+#                           checkpoint timeline collected by zsh_startup_mark
+#                           (see below). ~/.zshenv turns it on by default, and
+#                           the marks sit at the end of each of the three
+#                           startup files. The timeline is only ever printed
+#                           under the notice it explains, so a budget that
+#                           silences one silences both.
+
+# Sourced before anything else happens, so that it can turn the rest off. A
+# file that is not there costs one stat and no fork.
+[[ -r $HOME/scriptlets/zsh-startup ]] && source $HOME/scriptlets/zsh-startup
+
+# The off switch. ~/.zshenv defines a no-op zsh_startup_mark when this file
+# defines nothing, so the marks left behind in the three startup files stay
+# harmless.
+case ${ZSH_STARTUP_PROFILE-1} in
+  ''|0|no|off|false) return 0 ;;
+esac
+
+zmodload zsh/datetime
+: ${ZSH_STARTUP_T0:=$EPOCHREALTIME}
+
+# Checkpoints. Call `zsh_startup_mark <label>` anywhere in the rc chain -- at
+# the end of ~/.zprofile, at the end of ~/.zshrc, around a suspect block -- and
+# the first prompt prints the timeline. This is the only instrument that sees
+# the real session: a benchmark shell has no tty, no terminal integration and
+# no prompt, so anything the terminal itself costs is invisible to hyperfine
+# and shows up here as the gap between the last mark and the prompt.
+#
+# Defined before the interactive guard so a mark in ~/.zshenv is safe in
+# scripts too. Two array appends, no forks.
+typeset -ga ZSH_STARTUP_MARK_AT ZSH_STARTUP_MARK_LABEL
+zsh_startup_mark() {
+  ZSH_STARTUP_MARK_AT+=( $(( (EPOCHREALTIME - ZSH_STARTUP_T0) * 1000 )) )
+  ZSH_STARTUP_MARK_LABEL+=( ${1:-mark} )
+}
+
+[[ -o interactive ]] || return 0
+
+[[ -n ${ZSH_STARTUP_ZPROF:-} ]] && zmodload zsh/zprof
+
+: ${ZSH_STARTUP_LOG=${XDG_STATE_HOME:-$HOME/.local/state}/zsh-startup.log}
+# `=` rather than `:=`, so an explicitly empty value survives and stays silent.
+: ${ZSH_STARTUP_BUDGET_MS=0}
+
+_zsh_startup_record() {
+  add-zsh-hook -d precmd _zsh_startup_record
+
+  local -F ms=$(( (EPOCHREALTIME - ZSH_STARTUP_T0) * 1000 ))
+
+  if [[ -n $ZSH_STARTUP_LOG ]]; then
+    local dir=${ZSH_STARTUP_LOG:h} stamp kind=interactive
+    [[ -o login ]] && kind=login
+    strftime -s stamp '%Y-%m-%dT%H:%M:%S%z' $EPOCHSECONDS
+    [[ -d $dir ]] || mkdir -p $dir
+    # One short line, opened and closed per shell: concurrent terminals append
+    # without stepping on each other, and any editor can read it. `>>|` appends
+    # even under noclobber, including the very first time.
+    printf '%s\t%.0f\t%s\t%s\n' \
+      $stamp $ms ${TERM_PROGRAM:-unknown} $kind >>| $ZSH_STARTUP_LOG
+  fi
+
+  local -i speaks=0
+  if [[ -n $ZSH_STARTUP_BUDGET_MS ]] && (( ms > ZSH_STARTUP_BUDGET_MS )); then
+    speaks=1
+    if (( ZSH_STARTUP_BUDGET_MS > 0 )); then
+      printf 'zsh startup %.0f ms (budget %s ms) -- zsh-startup-bench\n' \
+        $ms $ZSH_STARTUP_BUDGET_MS >&2
+    else
+      printf 'zsh startup %.0f ms\n' $ms >&2
+    fi
+  fi
+
+  # Only ever under the line it breaks down. A timeline on its own would be a
+  # report from a startup that was told to keep quiet, and a budget that still
+  # printed five lines per prompt would not be a way to quieten anything.
+  if (( speaks )) && [[ -n ${ZSH_STARTUP_MARKS:-} ]] && (( $#ZSH_STARTUP_MARK_AT )); then
+    local -F prev=0
+    local i
+    for i in {1..$#ZSH_STARTUP_MARK_AT}; do
+      printf '  %7.1f ms  %-16s (+%.1f)\n' \
+        $ZSH_STARTUP_MARK_AT[i] $ZSH_STARTUP_MARK_LABEL[i] \
+        $(( ZSH_STARTUP_MARK_AT[i] - prev )) >&2
+      prev=$ZSH_STARTUP_MARK_AT[i]
+    done
+    printf '  %7.1f ms  %-16s (+%.1f)\n' $ms 'first prompt' $(( ms - prev )) >&2
+  fi
+
+  [[ -n ${ZSH_STARTUP_ZPROF:-} ]] && zprof
+
+  return 0
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _zsh_startup_record

--- a/rcm/zshenv
+++ b/rcm/zshenv
@@ -1,12 +1,26 @@
-# >>> zsh startup profiling (new-macbook-2026) >>>
-[[ -r ~/git/new-macbook-2026/scripts/zsh-startup-profile.zsh ]] && source ~/git/new-macbook-2026/scripts/zsh-startup-profile.zsh
-export ZSH_STARTUP_MARKS=1
+# ~/.zshenv: read by every zsh there is, before anything else.
+#
+# Little else belongs here -- a script, a `zsh -c` from an editor and a cron job
+# all pay for whatever this file does. The startup profiler has to be here
+# precisely because this file is read first: sourced any later, it could not see
+# the time the earlier files took.
+
+# >>> zsh startup profiling >>>
+[[ -r ~/.zsh-startup-profile.zsh ]] && source ~/.zsh-startup-profile.zsh
+# The timeline is on by default here, and `=` rather than `:=` or a plain
+# assignment is what makes that a default rather than a decree: a value from the
+# environment, or from ~/scriptlets/zsh-startup which the profiler reads a
+# moment earlier, survives -- including an empty one, which is how the timeline
+# is switched off without touching the dotfiles every machine shares.
+: ${ZSH_STARTUP_MARKS=1}
+export ZSH_STARTUP_MARKS
 # The marks here, in ~/.zprofile and in ~/.zshrc call a function that only the
-# profiler above defines, and that profiler lives in a repository which is only
-# on the machine it was written for. Everywhere else, every zsh start said
+# profiler above defines -- and it defines nothing when profiling is switched
+# off, or when the file is not installed at all, as on an account whose
+# ~/.zshenv came from somewhere else. Without a fallback, such a zsh start said
 # `command not found: zsh_startup_mark`, once per startup file it read.
 # ~/.zshenv is read first by every zsh there is, so one no-op here covers all
-# three, and the real function still wins wherever it is installed.
+# three, and the real function still wins wherever it is loaded.
 (( $+functions[zsh_startup_mark] )) || zsh_startup_mark() { : }
 zsh_startup_mark zshenv
 # <<< zsh startup profiling <<<

--- a/rcm/zshrc
+++ b/rcm/zshrc
@@ -3,10 +3,6 @@
 # The PATH is set up in ~/.profile, which ~/.zprofile hands to zsh at login;
 # this file is only for what an interactive shell needs.
 
-# >>> zsh startup profiling (new-macbook-2026) >>>
-zsh_startup_mark zshrc
-# <<< zsh startup profiling <<<
-
 # The completion system, unless something has already started it.
 #
 # -i skips insecure directories rather than stopping to ask about them: with no
@@ -127,3 +123,10 @@ if [[ $TERM_PROGRAM == vscode ]]; then
 fi
 
 compdef g=git
+
+# Last line on purpose: the mark records when this file was *done*, and the gap
+# between it and the first prompt is everything the terminal does after the
+# configuration has finished.
+# >>> zsh startup profiling >>>
+zsh_startup_mark zshrc
+# <<< zsh startup profiling <<<

--- a/tests/checks/60-zsh-startup.sh
+++ b/tests/checks/60-zsh-startup.sh
@@ -39,6 +39,10 @@ assert_equal "~/.zshrc is installed" \
 # Interactive *and* login, so that all three files are read. Only complaints
 # that name a file in this home directory count: a system-wide zshrc with
 # opinions of its own is not ours to fix.
+#
+# The startup profiler is deliberately not silent, and does not show up here
+# either way: `-c` never reaches a prompt, which is where it reports.
+# tests/checks/65-zsh-startup-profile.sh covers what it says and when.
 noise=$(zsh -ilc true </dev/null 2>&1 >/dev/null | grep -F "$HOME" || true)
 
 if [ -z "$noise" ]; then

--- a/tests/checks/65-zsh-startup-profile.sh
+++ b/tests/checks/65-zsh-startup-profile.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# The startup profiler: it measures every interactive shell, it stays out of
+# the way of every other one, and it can be switched off.
+#
+# All three halves are worth a check. A profiler that never records leaves the
+# `--log` summary empty and nobody notices; one that records a `zsh -c` from an
+# editor fills the log with shells nobody started; and one that cannot be
+# switched off is a line of output at every prompt, for good.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+if ! command -v zsh >/dev/null 2>&1; then
+    skip "zsh: not installed"
+    exit 0
+fi
+
+LOG="$HOME/zsh-startup-check.log"
+export LOG
+ZSH_STARTUP_LOG="$LOG"
+export ZSH_STARTUP_LOG
+
+# What a new terminal tab does: an interactive login shell that reaches a
+# prompt, which is the moment the precmd hook fires and the whole mechanism
+# runs. Stdin is a pipe rather than a terminal, which is as close as a check
+# gets; what comes back is stderr, where the report goes.
+startup() {
+    : >"$LOG"
+    printf 'exit\n' | zsh -li 2>&1 >/dev/null
+}
+
+log_lines() {
+    if [ -s "$LOG" ]; then
+        wc -l <"$LOG" | tr -d ' '
+    else
+        echo 0
+    fi
+}
+
+# The timeline, as labels alone: `zshenv zprofile zshrc first prompt`.
+timeline() {
+    printf '%s\n' "$1" |
+        sed -n 's/^ *[0-9][0-9.]* ms  *\([a-z][a-z ]*[a-z]\) *(.*/\1/p' |
+        tr '\n' ' ' | sed 's/ *$//'
+}
+
+assert_equal "the profiler is installed" \
+    "$REPO/rcm/zsh-startup-profile.zsh" \
+    "$(readlink "$HOME/.zsh-startup-profile.zsh" 2>/dev/null)"
+
+output=$(startup)
+
+assert_equal "a shell that reaches a prompt is recorded once" 1 "$(log_lines)"
+
+# stamp, milliseconds, terminal, kind -- tab separated, one line per shell, so
+# that `cut -f2` and the awk in zsh-startup-bench keep working.
+assert_equal "the log line carries stamp, milliseconds, terminal and kind" \
+    "4 login" \
+    "$(awk -F'\t' 'NR == 1 { printf "%d %s", NF, $4 }' "$LOG")"
+
+if awk -F'\t' 'NR == 1 && $2 ~ /^[0-9]+$/ { found = 1 } END { exit !found }' "$LOG"; then
+    pass "the logged duration is a whole number of milliseconds"
+else
+    fail "the logged duration is a whole number of milliseconds" "$(cat "$LOG")"
+fi
+
+assert_equal "the timeline names every startup file, in the order they are read" \
+    "zshenv zprofile zshrc first prompt" "$(timeline "$output")"
+
+case $output in
+*"not found"*)
+    fail "the startup says nothing about a missing command" "$output"
+    ;;
+*)
+    pass "the startup says nothing about a missing command"
+    ;;
+esac
+
+# The benchmark shape: `zsh -i -c` loads the whole rc chain but never reaches a
+# prompt, which is what keeps hyperfine runs out of the production record.
+: >"$LOG"
+zsh -lic 'exit 0' >/dev/null 2>&1 || true
+assert_equal "a shell that never reaches a prompt is not recorded" 0 "$(log_lines)"
+
+: >"$LOG"
+zsh -lc true >/dev/null 2>&1 || true
+zsh -c true >/dev/null 2>&1 || true
+assert_equal "a non-interactive shell is not recorded" 0 "$(log_lines)"
+
+# The off switch, from the environment.
+: >"$LOG"
+off=$(printf 'exit\n' | ZSH_STARTUP_PROFILE=0 zsh -li 2>&1 >/dev/null)
+
+assert_equal "ZSH_STARTUP_PROFILE=0 records nothing" 0 "$(log_lines)"
+assert_equal "ZSH_STARTUP_PROFILE=0 prints no timeline" "" "$(timeline "$off")"
+
+case $off in
+*"not found"*)
+    fail "the marks are harmless with the profiler switched off" "$off"
+    ;;
+*)
+    pass "the marks are harmless with the profiler switched off"
+    ;;
+esac
+
+# The off switch, from the file that outlives a shell -- the one a machine uses
+# to opt out of what the shared dotfiles switch on.
+local_config="$HOME/scriptlets/zsh-startup"
+mkdir -p "$HOME/scriptlets"
+saved=
+if [ -e "$local_config" ]; then
+    saved="$local_config.saved-by-check"
+    mv "$local_config" "$saved"
+fi
+printf 'ZSH_STARTUP_PROFILE=0\n' >"$local_config"
+
+off=$(startup)
+assert_equal "~/scriptlets/zsh-startup records nothing when it switches the profiler off" \
+    0 "$(log_lines)"
+assert_equal "~/scriptlets/zsh-startup prints no timeline when it switches the profiler off" \
+    "" "$(timeline "$off")"
+
+# Quiet, but still measuring: the state a machine settles into once the number
+# is boring.
+printf 'ZSH_STARTUP_BUDGET_MS=\n' >"$local_config"
+quiet=$(startup)
+assert_equal "an empty budget says nothing" "" "$(timeline "$quiet")"
+assert_equal "an empty budget keeps recording" 1 "$(log_lines)"
+
+rm -f "$local_config"
+if [ -n "$saved" ]; then
+    mv "$saved" "$local_config"
+fi
+
+# The log is read back by the script that ships with it.
+if [ -x "$HOME/bin/zsh-startup-bench" ]; then
+    startup >/dev/null
+    summary=$("$HOME/bin/zsh-startup-bench" --log 2>&1 || true)
+    case $summary in
+    *"shells   1"*)
+        pass "zsh-startup-bench --log summarises the log"
+        ;;
+    *)
+        fail "zsh-startup-bench --log summarises the log" "$summary"
+        ;;
+    esac
+else
+    fail "zsh-startup-bench is installed" "no $HOME/bin/zsh-startup-bench"
+fi
+
+# Where the log goes when nothing says otherwise. The directory does not exist
+# on a fresh account, and the profiler is the one that has to create it.
+(
+    unset ZSH_STARTUP_LOG XDG_STATE_HOME
+    rm -rf "$HOME/.local/state"
+    printf 'exit\n' | zsh -li >/dev/null 2>&1
+
+    if [ -s "$HOME/.local/state/zsh-startup.log" ]; then
+        pass "the log lands in ~/.local/state by default"
+    else
+        fail "the log lands in ~/.local/state by default" \
+            "$(ls -la "$HOME/.local" 2>&1)"
+    fi
+)
+
+rm -f "$LOG"


### PR DESCRIPTION
The marks were already in the three zsh startup files,
but the profiler they call was not:
`~/.zshenv` sourced a fragment out of a `new-macbook-2026` checkout,
so every other machine got three marks, a no-op, and no measurement.
The fragment now lives here.

## What every shell does now

[`rcm/zsh-startup-profile.zsh`](https://github.com/krlmlr/scriptlets/blob/claude/zsh-startup-profiling-jry9wl/rcm/zsh-startup-profile.zsh)
installs as `~/.zsh-startup-profile.zsh`
and is sourced from the first line of `~/.zshenv` —
the first file every zsh reads,
so the measurement covers the whole rc chain rather than the tail of it.
An interactive shell appends one line to `~/.local/state/zsh-startup.log`
and reports before the first prompt:

```
zsh startup 61 ms
     0.4 ms  zshenv           (+0.4)
     6.1 ms  zprofile         (+5.7)
     8.2 ms  zshrc            (+2.1)
    61.0 ms  first prompt     (+52.8)
```

There are no forks in any of it,
one `precmd` hook that runs once and unhooks itself,
and a non-interactive shell — every script, every `zsh -c` —
returns after two builtin statements.
`zsh -i -c 'exit 0'` never reaches a prompt,
so benchmark runs stay out of the log by construction.

The three marks moved to the **last** line of their files,
which is what makes each line the cost of the file above it.
The final gap is the one no benchmark can see:
`first prompt` minus `zshrc` is everything the terminal itself does
after the configuration has finished.

## Turning it off

Documented in the README rather than left to be discovered,
and covered by a check.
The knobs are read from `~/scriptlets/zsh-startup`,
sourced before the profiler does anything,
so one machine can opt out of what the shared dotfiles switch on —
or from the environment, which makes `ZSH_STARTUP_PROFILE=0 zsh` a one-shot escape.

| Set | Effect |
| --- | --- |
| `ZSH_STARTUP_BUDGET_MS=500` | say nothing unless a startup exceeds the budget; keep recording |
| `ZSH_STARTUP_BUDGET_MS=` | say nothing, ever; keep recording |
| `ZSH_STARTUP_MARKS=` | keep the one-line notice, drop the timeline below it |
| `ZSH_STARTUP_LOG=` | stop recording; keep the notice |
| `ZSH_STARTUP_PROFILE=0` | off entirely: nothing is loaded, nothing is timed, nothing is written |

`ZSH_STARTUP_PROFILE=0` returns before a module is loaded or a function defined,
and the no-op `zsh_startup_mark` added in #28 absorbs the marks left behind.
One divergence from the fragment this started as:
the timeline is printed only under the notice it breaks down,
so setting a budget quietens both rather than five lines per prompt.

## `zsh-startup-bench`

[`rcm/bin/zsh-startup-bench`](https://github.com/krlmlr/scriptlets/blob/claude/zsh-startup-profiling-jry9wl/rcm/bin/zsh-startup-bench)
answers three different halves of the same question:
`--log` summarises the continuous log (count, min, median, p90, max, mean,
by terminal and by login versus interactive),
`--zprof` ranks one startup per function,
and the default mode benchmarks login, interactive and `zsh -f`
against each other with hyperfine —
the floor is what makes the rest legible.
Only that mode needs hyperfine; the other two need nothing but zsh.

## Also in here

`~/.bash_secrets` is now sourced only if it exists.
It reaches zsh through `~/.zshrc`,
so a machine without one opened every interactive shell with
`no such file or directory` —
which is what `tests/checks/60-zsh-startup.sh` has been failing on since #28,
on `main` and on both platforms.
It is unrelated to the profiling, and it is one line;
saying so here rather than in a PR of its own.

## Tests

`tests/checks/65-zsh-startup-profile.sh` covers all three halves:
a shell that reaches a prompt is timed, recorded once, and broken down by
startup file, in the order the files are read;
one that does not — a script, a `zsh -c`, a benchmark run — is left alone;
every documented off switch turns it off, from the environment and from
`~/scriptlets/zsh-startup` alike;
the marks stay harmless with the profiler off;
the log lands in `~/.local/state` when nothing says otherwise;
and `zsh-startup-bench --log` reads back what was written.

`mise run test` is green on Ubuntu, including `60-zsh-startup`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeBrJUiH1Bx3d3SuLDB8rS)_