### PR TITLE
feat: per-remote push aliases without `-u`, with the variant folded into the push stem

### DIFF
--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -94,22 +94,23 @@
 	lsf = "!f() { if [ ${GIT_PREFIX} != ${PWD} ]; then cd ${GIT_PREFIX}; fi; git ls-files $@ -z | xargs -0 -n1 '-I{}' -- git log -1 --format=%ai\\ {} '{}'; }; f"
 	mf = merge --ff
 	mu = merge-update
-	# The ph series: ph, then switches, then an optional remote.
-	# A switch is one letter;
-	# a remote is the first two letters of its name, comes last,
+	# Push: the second letter picks the variant,
+	# an optional third letter picks the remote
 	# and pushes the current branch.
+	# Variants: h plain, f --force-with-lease, t --follow-tags, u --set-upstream.
+	# Remotes: c cynkra, o origin, u upstream; k krlmlr, per user.
 	ph = push
-	phf = push --force-with-lease
-	pht = push --follow-tags
-	phu = push --set-upstream
+	pf = push --force-with-lease
+	pt = push --follow-tags
+	pu = push --set-upstream
 	# ---
-	phcy = push cynkra HEAD
-	phor = push origin HEAD
-	phup = push upstream HEAD
+	phc = push cynkra HEAD
+	pho = push origin HEAD
+	phu = push upstream HEAD
 	# ---
-	phucy = push --set-upstream cynkra HEAD
-	phuor = push --set-upstream origin HEAD
-	phuup = push --set-upstream upstream HEAD
+	puc = push --set-upstream cynkra HEAD
+	puo = push --set-upstream origin HEAD
+	puu = push --set-upstream upstream HEAD
 	pl = pull
 	plf = pull --ff-only
 	plr = pull --rebase

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -94,12 +94,22 @@
 	lsf = "!f() { if [ ${GIT_PREFIX} != ${PWD} ]; then cd ${GIT_PREFIX}; fi; git ls-files $@ -z | xargs -0 -n1 '-I{}' -- git log -1 --format=%ai\\ {} '{}'; }; f"
 	mf = merge --ff
 	mu = merge-update
+	# The ph series: ph, then switches, then an optional remote.
+	# A switch is one letter;
+	# a remote is the first two letters of its name, comes last,
+	# and pushes the current branch.
 	ph = push
 	phf = push --force-with-lease
 	pht = push --follow-tags
 	phu = push --set-upstream
-	phuc = push --set-upstream cynkra HEAD
-	phuo = push --set-upstream origin HEAD
+	# ---
+	phcy = push cynkra HEAD
+	phor = push origin HEAD
+	phup = push upstream HEAD
+	# ---
+	phucy = push --set-upstream cynkra HEAD
+	phuor = push --set-upstream origin HEAD
+	phuup = push --set-upstream upstream HEAD
 	pl = pull
 	plf = pull --ff-only
 	plr = pull --rebase

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -111,6 +111,10 @@
 	puc = push --set-upstream cynkra HEAD
 	puo = push --set-upstream origin HEAD
 	puu = push --set-upstream upstream HEAD
+	# ---
+	# The old spellings warn, then forward.
+	phuc = "!echo 'warning: phuc is now puc' >&2; git puc"
+	phuo = "!echo 'warning: phuo is now puo' >&2; git puo"
 	pl = pull
 	plf = pull --ff-only
 	plr = pull --rebase

--- a/rcm/tag-kirill/scriptlets/gitconfig
+++ b/rcm/tag-kirill/scriptlets/gitconfig
@@ -5,3 +5,5 @@
 	# The push series from ~/.gitaliases, for the personal remote: k = krlmlr.
 	phk = push krlmlr HEAD
 	puk = push --set-upstream krlmlr HEAD
+	# The old spelling warns, then forwards.
+	phuk = "!echo 'warning: phuk is now puk' >&2; git puk"

--- a/rcm/tag-kirill/scriptlets/gitconfig
+++ b/rcm/tag-kirill/scriptlets/gitconfig
@@ -2,6 +2,6 @@
 	email = kirill@cynkra.com
 	name = Kirill Müller
 [alias]
-	# The ph series from ~/.gitaliases, for the personal remote: kr = krlmlr.
-	phkr = push krlmlr HEAD
-	phukr = push --set-upstream krlmlr HEAD
+	# The push series from ~/.gitaliases, for the personal remote: k = krlmlr.
+	phk = push krlmlr HEAD
+	puk = push --set-upstream krlmlr HEAD

--- a/rcm/tag-kirill/scriptlets/gitconfig
+++ b/rcm/tag-kirill/scriptlets/gitconfig
@@ -2,4 +2,6 @@
 	email = kirill@cynkra.com
 	name = Kirill Müller
 [alias]
-	phuk = push --set-upstream krlmlr HEAD
+	# The ph series from ~/.gitaliases, for the personal remote: kr = krlmlr.
+	phkr = push krlmlr HEAD
+	phukr = push --set-upstream krlmlr HEAD


### PR DESCRIPTION
## The problem

The `ph` series mixed two namespaces after the `ph` stem:
switches (`phf`, `pht`, `phu`)
and remotes (`phuc`, `phuo`, and the personal `phuk`).
Adding plain pushes per remote as `phc`, `phk`, `pho`, `phu`
would have collided head-on:
`phu` already meant `push --set-upstream`,
and single letters after `ph` were a shrinking namespace —
`-o` (`--push-option`), `-d` (`--delete`) and `-n` (`--dry-run`)
are real `git push` switches that may want alias letters one day.

## The framework

Three letters: `p`, then the variant, then an optional remote.

- The **second letter picks the push variant**:
  `h` plain, `f` `--force-with-lease`, `t` `--follow-tags`, `u` `--set-upstream`.
- An optional **third letter picks the remote**
  and pushes the current branch (`HEAD`):
  `c` cynkra, `o` origin, `u` upstream; `k` krlmlr, per user.

With the variant folded into the stem,
the third position holds remotes only,
so a remote letter can never collide with a switch —
`phu` (push to upstream) and `pu` (`--set-upstream`) coexist.
`pf`, `pt`, and `pu` were free:
the `p` namespace held only `ph*`, `pl`/`plf`/`plr`, and `pr`/`prm`.

## The aliases

| | bare | cynkra | origin | upstream | krlmlr (tag-kirill) |
|---|---|---|---|---|---|
| plain | `ph` | `phc` | `pho` | `phu` | `phk` |
| `--force-with-lease` | `pf` | | | | |
| `--follow-tags` | `pt` | | | | |
| `--set-upstream` | `pu` | `puc` | `puo` | `puu` | `puk` |

Renames: `phf` → `pf`, `pht` → `pt`, `phu` → `pu`,
`phuc` → `puc`, `phuo` → `puo`, `phuk` → `puk`.
New: `phc`, `pho`, `phu`, `phk`, and `puu`.
Note the meaning change: `phu` now pushes to the `upstream` remote;
`--set-upstream` is `pu`.
The grid stays at the rows in use;
the grammar makes future cells like `pfo` self-naming.

## Deprecated spellings

The old four-letter combinations keep working:
`phuc`, `phuo`, and the personal `phuk`
print a warning to stderr
(`warning: phuc is now puc`)
and forward to `puc`, `puo`, and `puk`,
with any extra arguments appended.
The three-letter `phf`, `pht`, and `phu` cannot be kept:
`phu` is reassigned, and `pf`/`pt` replace the others outright.

## Alternatives considered

- **Switches stay on `ph`, two-letter remote codes** (`phcy`, `phor`, `phup`):
  collision-free, but longer,
  and one-letter remotes are preferred.
- **Keep `ph*` switches and dodge the clash per remote**:
  inconsistent for upstream,
  and still squatting on future switch letters.
- **Uppercase remote letters** (`phC`):
  impossible — git config keys are case-insensitive.

## Testing

- `tests/run` passes (all checks ok, zsh check skipped as not installed).
- Both files parse via `git config -f`,
  and expansion was smoke-tested in a throwaway repository:
  `git phc` pushes `HEAD` to `cynkra`,
  and `git phuc` warns, then pushes with `--set-upstream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ubz3k3UhbnSWRxuxYxwHba