### PR TITLE
perf: audit zsh's completion dump once a day, not once a shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ bash and fish are on their own — `mise completion bash` or `fish`.
 - [`rcm/zprofile`](rcm/zprofile): installed as `~/.zprofile`,
   hands `~/.profile` to zsh, which would not read it otherwise.
 - [`rcm/zshrc`](rcm/zshrc): installed as `~/.zshrc`,
-  starts the completion system and registers mise's completion lazily.
+  starts the completion system — audited once a day, trusted in between,
+  see [below](#the-first-thing-the-profiling-found) —
+  and registers mise's completion lazily.
 - [`rcm/zshenv`](rcm/zshenv): installed as `~/.zshenv`, read by every zsh
   before anything else.
   It loads the [startup profiler](#zsh-startup-profiling), and defines a no-op
@@ -430,6 +432,57 @@ tail -n 5000 ~/.local/state/zsh-startup.log > ~/.local/state/zsh-startup.log.tmp
 and it answers three different questions —
 see [below](#zsh-startup-bench).
 
+### The first thing the profiling found
+
+`zsh-startup-bench --zprof` put `compinit` at 95% of the rc chain's function
+time, and half of *that* was `compaudit`.
+
+`compinit -i` does not skip the security audit,
+it only stops it from asking:
+compaudit still stats every directory in `$fpath`,
+which on macOS means Homebrew's `site-functions` and a good part of `/usr/share`.
+That is worth doing.
+It is not worth doing at every single shell start.
+
+So [`rcm/zshrc`](rcm/zshrc) audits when the dump is more than a day old,
+and every shell in between takes `compinit -C`,
+which trusts the dump and calls no compaudit at all.
+The dump is compiled to wordcode as well —
+zsh reads `zcompdump-<version>.zwc` in place of the dump whenever it is newer,
+and parsing the dump is most of what `-C` leaves behind.
+Both live under `~/.cache/zsh/`,
+next to a `.audited` stamp that dates the last audit.
+
+The stamp is a separate file rather than the dump's own mtime for a reason:
+compinit rewrites the dump only when the number of completion functions has
+changed,
+so on a machine that installs nothing the dump's mtime stands still —
+and using it as the clock would mean auditing at every start
+from the second day on.
+
+The tradeoff is that a tool installed today does not complete until tomorrow.
+That is what [`zsh-compinit-refresh`](rcm/bin/zsh-compinit-refresh) is for:
+
+```sh
+zsh-compinit-refresh    # then `exec zsh`, or just open a new tab
+```
+
+It removes the dump, its wordcode and the stamp,
+and lets a fresh interactive zsh build a new one through `~/.zshrc`,
+so the rebuild has one implementation and the script only decides when it runs.
+The shell you run it from keeps the completions it started with —
+they are loaded, not looked up — hence the `exec zsh`.
+A leftover `~/.zcompdump` from before the dump moved into `~/.cache` is
+removed too.
+
+Going further would mean not running `compinit` at all until the first Tab.
+It is worth about another 10 ms and it is awkward here:
+`bashcompinit`, the `complete` calls `~/.bash_aliases` makes,
+`compdef _mise_lazy mise` and `compdef g=git`
+all need `compdef` to exist at startup,
+so it takes a queueing `compdef` stub and a Tab widget that replays the queue.
+More to go wrong than the five lines above, for a smaller win.
+
 ## Tests
 
 `mise run test` installs everything into a throw-away home directory
@@ -478,6 +531,12 @@ and they run in name order:
 - `60-zsh-startup`: a zsh startup complains about nothing, and `~/.zshrc` binds
   `mise` to the stub — the generated completion is *not* loaded at startup, and
   the first completion loads it and rebinds to it.
+  It also covers the completion dump: written and compiled by the first shell,
+  trusted by the next, re-audited once the stamp is a day old, and rebuilt on
+  demand by `zsh-compinit-refresh`.
+  The audit is observed through a sentinel written into the stamp, which the
+  audit truncates — mtimes cannot tell a re-audit within the same second from
+  no audit at all.
 - `65-zsh-startup-profile`: a shell that reaches a prompt is timed, recorded
   once and broken down by startup file; one that does not — a script, a
   `zsh -c`, a benchmark run — is left alone; and every documented way of
@@ -591,6 +650,17 @@ Files are discovered with `ag`.
 
 Run `air format` on a single file if the containing Git repository has an `air.toml` file.
 Useful as a formatter in the RStudio IDE.
+
+## zsh-compinit-refresh
+
+Rebuild zsh's completion dump now, audit and all.
+
+`~/.zshrc` audits `$fpath` only when the dump is more than a day old
+and trusts the dump in between,
+which is why a tool installed five minutes ago does not complete yet.
+This is the way to say "now" —
+described with the rest of the mechanism
+[above](#the-first-thing-the-profiling-found).
 
 ## zsh-startup-bench
 

--- a/rcm/bin/zsh-compinit-refresh
+++ b/rcm/bin/zsh-compinit-refresh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Rebuild zsh's completion dump now, audit and all.
+#
+#   zsh-compinit-refresh
+#
+# ~/.zshrc runs the compaudit security check only when the dump is more than a
+# day old, and every shell in between trusts the dump (`compinit -C`). That is
+# what makes a shell start cheap, and it is also why a tool installed five
+# minutes ago does not complete yet: its completion function was not in $fpath
+# when the dump was written.
+#
+# This throws the dump away and lets a fresh interactive zsh build a new one,
+# through ~/.zshrc, so there is one implementation of the rebuild and this
+# script only decides when it happens.
+#
+# The shell you run it from keeps the completions it started with -- they are
+# loaded, not looked up. `exec zsh` picks the new ones up, and so does the next
+# terminal tab.
+#
+# ~/.zcompdump is removed too: it is where compinit wrote before the dump moved
+# under ~/.cache, and nothing reads it any more.
+
+set -euo pipefail
+
+case "${1:-}" in
+  -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
+  "") ;;
+  *) echo "unknown option: $1" >&2; exit 2 ;;
+esac
+
+command -v zsh >/dev/null || { echo "zsh not found on PATH" >&2; exit 1; }
+
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
+
+tilde() { printf '%s\n' "${1/#$HOME/\~}"; }
+
+# The wildcard covers the dump, its .zwc and the .audited stamp that dates the
+# last audit -- taking the stamp with it is what makes the next shell audit
+# rather than trust what it finds.
+removed=0
+for file in "$CACHE"/zcompdump-* "$HOME"/.zcompdump "$HOME"/.zcompdump.zwc; do
+  if [ -e "$file" ]; then
+    rm -f "$file"
+    removed=$((removed + 1))
+  fi
+done
+
+echo "removed $removed file(s)"
+
+# An interactive shell, because ~/.zshrc is where the rebuild lives. `-c` never
+# reaches a prompt, so this costs one compinit and not a whole session.
+zsh -ic true
+
+built=0
+for file in "$CACHE"/zcompdump-*; do
+  case "$file" in
+    *.zwc | *.audited | *'zcompdump-*') continue ;;
+  esac
+  [ -e "$file" ] || continue
+  echo "wrote $(tilde "$file")"
+  built=$((built + 1))
+done
+
+if [ "$built" -eq 0 ]; then
+  echo "no dump was written -- is ~/.zshrc the one from scriptlets?" >&2
+  exit 1
+fi
+
+echo "run \`exec zsh\` to pick the new completions up in this shell"

--- a/rcm/zshrc
+++ b/rcm/zshrc
@@ -8,9 +8,51 @@
 # -i skips insecure directories rather than stopping to ask about them: with no
 # terminal to ask on -- a script, a container, `zsh -c` -- plain compinit aborts
 # and leaves no compdef behind at all.
+#
+# The audit is what costs. `-i` does not skip it, it only stops it from asking:
+# compaudit still stats every directory in $fpath, which on macOS is Homebrew's
+# site-functions and a good part of /usr/share, and it was half of what the
+# whole rc chain spent (`zsh-startup-bench --zprof`). It is worth doing, and it
+# is not worth doing at every single shell start -- so the audit runs when the
+# dump is more than a day old, and every other shell trusts the dump.
+#
+# `zsh-compinit-refresh` forces the refresh, for the day a newly installed tool
+# should complete right now rather than tomorrow.
 if ! (( $+functions[compdef] )); then
     autoload -Uz compinit
-    compinit -i
+
+    () {
+        local dump=${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump-$ZSH_VERSION
+        [[ -d ${dump:h} ]] || mkdir -p ${dump:h}
+
+        # When the audit last ran, kept apart from the dump on purpose: compinit
+        # rewrites the dump only when the number of completion functions has
+        # changed, so the dump's own mtime stands still on a machine that
+        # installs nothing -- and using it as the clock would mean auditing at
+        # every start from the second day on, which is the bug this file is
+        # trying to fix.
+        local stamp=$dump.audited
+
+        # Nmh-24: the stamp exists and is less than 24 hours old. The glob has
+        # to happen in an array assignment -- [[ ]] never globs, so the
+        # `[[ -n $stamp(#qNmh-24) ]]` spelling that circulates is always true,
+        # and silently means "never audit again".
+        local -a fresh=( $stamp(Nmh-24) )
+
+        if (( $#fresh )) && [[ -s $dump ]]; then
+            # -C: trust the dump. No compaudit, and no check for completion
+            # functions that appeared since it was written.
+            compinit -C -d $dump
+        else
+            compinit -i -d $dump
+            : >| $stamp
+
+            # zsh reads $dump.zwc in place of $dump whenever it is the newer of
+            # the two, and parsing the dump is most of what -C leaves behind.
+            [[ -f $dump.zwc && ! $dump -nt $dump.zwc ]] ||
+                zcompile -R -- $dump 2>/dev/null
+        fi
+    }
 fi
 
 # mise's completions are generated on demand -- `mise completion zsh` shells out

--- a/tests/checks/60-zsh-startup.sh
+++ b/tests/checks/60-zsh-startup.sh
@@ -59,3 +59,91 @@ assert_equal "the generated completion is not loaded at startup" \
 
 assert_equal "the first completion loads the real one and rebinds to it" \
     "_mise" "$(probe '_mise_lazy >/dev/null 2>&1; print "probe=${_comps[mise]}"')"
+
+# ---------------------------------------------------------------------------
+# The completion dump: audited once a day, trusted in between.
+#
+# `compinit -i` does not skip the security audit, it only stops it from asking,
+# and compaudit stats every directory in $fpath -- half of what the whole rc
+# chain spent. ~/.zshrc therefore audits only when the .audited stamp is more
+# than a day old, and `compinit -C` trusts the dump for every shell in between.
+#
+# The stamp is written with `: >| $stamp`, which truncates it, so a sentinel
+# written into it says exactly what happened: gone means the audit ran, intact
+# means the dump was trusted. Timestamps could not tell the two apart -- a
+# re-audit within the same second leaves the same mtime behind.
+# ---------------------------------------------------------------------------
+
+dump_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
+rm -rf "$dump_dir"
+
+zsh -ic true >/dev/null 2>&1
+
+dump=
+for candidate in "$dump_dir"/zcompdump-*; do
+    case $candidate in
+    *.zwc | *.audited | *'zcompdump-*') continue ;;
+    esac
+    [ -e "$candidate" ] && dump=$candidate
+done
+
+if [ -n "$dump" ]; then
+    pass "the first interactive shell writes a completion dump"
+else
+    fail "the first interactive shell writes a completion dump" \
+        "$(ls -la "$dump_dir" 2>&1)"
+fi
+
+if [ -n "$dump" ]; then
+    # Wordcode, which is what zsh reads in place of the dump when it is newer.
+    if [ -s "$dump.zwc" ]; then
+        pass "the dump is compiled to wordcode"
+    else
+        fail "the dump is compiled to wordcode" "$(ls -la "$dump_dir" 2>&1)"
+    fi
+
+    printf 'sentinel\n' >"$dump.audited"
+    zsh -ic true >/dev/null 2>&1
+    assert_equal "a second shell trusts the dump instead of auditing again" \
+        "sentinel" "$(cat "$dump.audited" 2>&1)"
+
+    # More than a day old, so the audit is due again.
+    touch -t 202001010000 "$dump.audited"
+    zsh -ic true >/dev/null 2>&1
+    assert_equal "a stamp older than a day makes the next shell audit" \
+        "" "$(cat "$dump.audited" 2>&1)"
+
+    # And the audit has to date itself, or every shell from the second day on
+    # pays for one: compinit leaves the dump's own mtime alone when the set of
+    # completion functions has not changed.
+    printf 'sentinel\n' >"$dump.audited"
+    touch -t 202001010000 "$dump.audited"
+    zsh -ic true >/dev/null 2>&1
+    zsh -ic true >/dev/null 2>&1
+    printf 'sentinel\n' >"$dump.audited"
+    zsh -ic true >/dev/null 2>&1
+    assert_equal "the audit dates itself, so the next shell trusts the dump" \
+        "sentinel" "$(cat "$dump.audited" 2>&1)"
+fi
+
+# The escape hatch, for the tool installed five minutes ago.
+if [ -x "$HOME/bin/zsh-compinit-refresh" ]; then
+    [ -n "$dump" ] && printf 'sentinel\n' >"$dump.audited"
+    refresh=$("$HOME/bin/zsh-compinit-refresh" 2>&1) || refresh="FAILED: $refresh"
+
+    case $refresh in
+    *"wrote "*)
+        pass "zsh-compinit-refresh rebuilds the dump"
+        ;;
+    *)
+        fail "zsh-compinit-refresh rebuilds the dump" "$refresh"
+        ;;
+    esac
+
+    if [ -n "$dump" ]; then
+        assert_equal "zsh-compinit-refresh audits rather than trusting the stamp" \
+            "" "$(cat "$dump.audited" 2>&1)"
+    fi
+else
+    fail "zsh-compinit-refresh is installed" "no $HOME/bin/zsh-compinit-refresh"
+fi


### PR DESCRIPTION
Acting on what #29 measured.
`zsh-startup-bench --zprof` put `compinit` at 95% of the rc chain's function
time, and half of that was `compaudit`:

```
num  calls                time                       self            name
 1)    1          20.41    20.41   95.41%     10.29    10.29   48.08%  compinit
 2)    2          10.13     5.06   47.33%     10.13     5.06   47.33%  compaudit
```

`compinit -i` does not skip the security audit,
it only stops it from asking —
compaudit still stats every directory in `$fpath`,
which on macOS is Homebrew's `site-functions` and a good part of `/usr/share`.
Worth doing; not worth doing at every single shell start.

## What changed

`~/.zshrc` audits when the dump is more than a day old,
and every shell in between takes `compinit -C`,
which trusts the dump and calls no compaudit at all.
The dump is compiled to wordcode too —
zsh reads `zcompdump-<version>.zwc` in place of the dump whenever it is newer,
and parsing the dump is most of what `-C` leaves behind.
Both now live under `~/.cache/zsh/`.

**The clock is a separate `.audited` stamp, not the dump's mtime.**
This is the part that is easy to get wrong,
and my first draft did:
compinit rewrites the dump only when the *number* of completion functions has
changed,
so on a machine that installs nothing the dump's mtime stands still —
and a dump-mtime clock would have audited at every start from the second day
on, which is exactly the cost being removed.
The stamp is written with `: >| $stamp`, forkless.

Two smaller details, both deliberate:
the freshness glob happens in an array assignment,
because `[[ ]]` never globs and the `[[ -n $stamp(#qNmh-24) ]]` spelling that
circulates is therefore always true (silently meaning "never audit again");
and `zcompile` only runs when the wordcode is missing or older than the dump.

## `zsh-compinit-refresh`

The tradeoff is that a tool installed today does not complete until tomorrow,
so:

```console
$ zsh-compinit-refresh
removed 3 file(s)
wrote ~/.cache/zsh/zcompdump-5.9
run `exec zsh` to pick the new completions up in this shell
```

It removes the dump, its wordcode and the stamp,
then lets a fresh interactive zsh rebuild through `~/.zshrc` —
one implementation of the rebuild, and the script only decides when it runs.
The shell it is run from keeps the completions it started with
(they are loaded, not looked up), hence the `exec zsh`.
A leftover `~/.zcompdump` from before the move into `~/.cache` is removed too.

## Tests

`tests/checks/60-zsh-startup.sh` gains six assertions:
the first shell writes the dump and compiles it,
the second trusts it,
a stamp older than a day makes the next shell audit,
the audit dates itself so the shell after that trusts the dump again,
and `zsh-compinit-refresh` rebuilds and re-audits.

The audit is observed through a sentinel written into the stamp,
which the audit truncates.
Timestamps cannot do this job —
a re-audit within the same second leaves the same mtime behind,
and an inode comparison fails for the same reason compinit's own mtime does.
Both failure modes were mutation-tested:
forcing the audit off, and dropping the stamp write,
each turn the relevant assertions red.

`mise run test` is green on Ubuntu.

## Not done

Deferring `compinit` entirely until the first Tab is worth maybe another 10 ms
and is awkward here:
`bashcompinit`, the `complete` calls `~/.bash_aliases` makes,
`compdef _mise_lazy mise` and `compdef g=git`
all need `compdef` at startup,
so it takes a queueing `compdef` stub plus a Tab widget that replays the queue.
More to go wrong than these five lines, for a smaller win.
Noted in the README rather than built.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeBrJUiH1Bx3d3SuLDB8rS)_