### PR TITLE
feat: time the test run, and every check in it

### DIFF
--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -48,6 +48,14 @@ and they run in name order:
   has the rules it enforces).
   It reads the repository, not the home directory,
   so it is first, before the installed checks.
+- `06-timing`: the clock behind the durations answers in milliseconds —
+  measured against a sleep rather than assumed,
+  because a fallback that answered in seconds
+  would fill the block with zeroes that read like measurements —
+  and the block lines up the durations it is given.
+  It calls the helpers directly,
+  reading neither the repository nor the home directory,
+  so it runs before the installed checks too.
 - `10-path`: the scripts are on the `PATH` of a login shell,
   in every shell an account may log in with, and they run.
 - `15-tasks`: a bare `mise run` offers the task list
@@ -99,3 +107,33 @@ and they run in name order:
 Adding a file to `tests/checks` is enough;
 `tests/run 10-path` runs one check by name,
 and `KEEP_TEST_HOME=1` leaves the home directory behind to look at.
+
+## Durations
+
+A run ends with a block of durations —
+the install it opens with, every check it ran, and the run as a whole —
+printed before the verdict,
+so a failing run says where its time went as well as a passing one.
+The whole run is wall clock rather than the sum of the parts,
+because it also covers making the throw-away home directory
+and seeding it.
+
+The block is what makes the numbers attributable in CI:
+a job times its own steps,
+and the entire suite is one step of one job,
+so without it the slow check is invisible inside the fast-looking job.
+
+There is no millisecond clock in POSIX `sh`
+and none that every machine has,
+so [`tests/timing.sh`](/tests/timing.sh) looks for one —
+`date +%N` is GNU's, macOS does not have it,
+and `perl` and `python3` both carry a sub-second clock —
+and the order it tries is that file's.
+A machine with nothing better than whole seconds is timed in them
+and says so above the block,
+rather than reporting a column of zeroes as if they were measurements.
+
+`TEST_TIMING=0`, or an empty value, drops the block;
+anything else, including leaving it unset, keeps it,
+which is the default [`tests/run`](/tests/run) sets.
+A run that will not print the durations does not measure them either.

--- a/tests/checks/06-timing.sh
+++ b/tests/checks/06-timing.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# The durations a run ends with: the clock behind them, and the block itself.
+#
+# The clock is the part that travels badly -- `date +%N` is GNU's alone, and a
+# fallback that silently answers in seconds would fill the block with zeroes
+# that read like measurements. So the resolution is measured against a sleep
+# rather than assumed, and a machine with nothing better than whole seconds
+# says so here too.
+#
+# It sources the helpers and calls them, reading neither the repository nor
+# the home directory, so it runs before the installed checks.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+. "$(dirname -- "$0")/../timing.sh"
+
+timing_init
+
+# --- the clock -------------------------------------------------------------
+
+now=$(now_ms)
+
+case $now in
+'' | *[!0-9]*)
+    fail "now_ms answers in digits" "now_ms=$now, clock=$TEST_CLOCK"
+    ;;
+*)
+    pass "now_ms answers in digits"
+    ;;
+esac
+
+# Milliseconds have been 13 digits since 2001 and stay 13 until 2286, so a
+# shorter answer is a clock in seconds wearing a millisecond label.
+assert_equal "now_ms answers in milliseconds, not seconds" \
+    "13" "${#now}"
+
+if [ "$TEST_CLOCK" = seconds ]; then
+    skip "a second of sleep measures a second (clock: whole seconds only)"
+else
+    started=$(now_ms)
+    sleep 1
+    elapsed=$(($(now_ms) - started))
+
+    # Loose on both sides on purpose: the point is that the clock moves with
+    # the sleep, not that a shared CI runner sleeps to the millisecond.
+    if [ "$elapsed" -ge 900 ] && [ "$elapsed" -le 3000 ]; then
+        pass "a second of sleep measures a second"
+    else
+        fail "a second of sleep measures a second" \
+            "$elapsed ms, clock=$TEST_CLOCK"
+    fi
+fi
+
+# --- the block -------------------------------------------------------------
+
+assert_equal "milliseconds below a second" "0 ms" "$(fmt_duration 0)"
+assert_equal "milliseconds up to the last one" "999 ms" "$(fmt_duration 999)"
+assert_equal "a second reads as seconds" "1.0 s" "$(fmt_duration 1000)"
+assert_equal "a tenth of a second survives" "1.4 s" "$(fmt_duration 1450)"
+assert_equal "a long run keeps its seconds" "125.0 s" "$(fmt_duration 125000)"
+
+report=$(printf '%s\n' "812 install" "55 05-handbook" "125000 total" |
+    timing_report)
+
+assert_equal "the block lines the durations up under each other" \
+    "#   812 ms  install
+#    55 ms  05-handbook
+#  125.0 s  total" "$report"

--- a/tests/run
+++ b/tests/run
@@ -7,11 +7,14 @@
 #   tests/run 10-path    run the named checks only
 #
 # KEEP_TEST_HOME=1 leaves the home directory behind for inspection.
+# TEST_TIMING=0 drops the block of durations the run otherwise ends with.
 
 set -eu
 
 REPO=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 export REPO
+
+. "$REPO/tests/timing.sh"
 
 if ! command -v rcup >/dev/null; then
     echo "rcm is required: apt install rcm / brew install rcm" >&2
@@ -22,6 +25,41 @@ if ! command -v mise >/dev/null; then
     echo "mise is required: https://mise.run" >&2
     exit 1
 fi
+
+# The durations, collected as `MILLISECONDS LABEL` lines and rendered at the
+# end by timing_report (tests/timing.sh). Anything richer than a number and a
+# label would have to survive the pipeline that prints them.
+timings=
+
+timing=1
+case ${TEST_TIMING-1} in
+'' | 0 | no | off | false) timing= ;;
+esac
+
+if [ -n "$timing" ]; then
+    timing_init
+fi
+
+# mark -- the clock now, or nothing at all when the durations are switched
+# off, so that a run which will not print them forks nothing to measure them.
+mark() {
+    if [ -n "$timing" ]; then
+        now_ms
+    fi
+}
+
+# record LABEL STARTED -- one line of the block, closing what mark opened.
+record() {
+    if [ -n "$timing" ]; then
+        timings="$timings$(($(now_ms) - $2)) $1
+"
+    fi
+}
+
+# Everything the run does is below this line, and the total covers all of it:
+# the throw-away home directory and its seeding are the run's work too, and a
+# total that quietly left them out would be smaller than the step CI times.
+run_started=$(mark)
 
 # The checks run tasks with HOME pointing at the throw-away directory, where
 # mise finds none of the trust it recorded for the real one. Naming the
@@ -78,7 +116,9 @@ echo "# mise run install"
 
 # Stdin comes from /dev/null throughout: rcup asks before replacing a file that
 # already exists and differs, and a check must never wait for an answer.
+started=$(mark)
 mise -q -C "$REPO" run install >/dev/null </dev/null
+record install "$started"
 
 status=0
 
@@ -91,8 +131,21 @@ for check in "$REPO"/tests/checks/*.sh; do
     fi
 
     echo "# $name"
+    started=$(mark)
     sh "$check" </dev/null || status=1
+    record "$name" "$started"
 done
+
+# Before the verdict, so that a run which ends in a failure still says where
+# its time went. The total is wall clock, not the sum of the lines above it.
+if [ -n "$timing" ]; then
+    echo "# durations"
+    if [ "$TEST_CLOCK" = seconds ]; then
+        echo "# no millisecond clock here -- whole seconds, rounded down"
+    fi
+    printf '%s%s total\n' "$timings" "$(($(now_ms) - run_started))" |
+        timing_report
+fi
 
 failures=$(wc -l <"$TEST_FAILURES" | tr -d ' ')
 

--- a/tests/timing.sh
+++ b/tests/timing.sh
@@ -1,0 +1,92 @@
+# Timing, sourced by `tests/run` and by the check that covers it.
+#
+# What is timed, and how to turn it off: handbook/testing/README.md.
+#
+# The suite is one step of one CI job, and a slow check is invisible inside
+# it: the job reports that the step took two minutes, and nothing says which
+# of the checks spent them. So the run times itself -- the install it starts
+# with, every check after it, and the whole run -- and ends with a block of
+# durations that says where the time went.
+#
+# There is no millisecond clock in POSIX sh, and none that every machine has:
+# `%N` is GNU date's and BSD date has nothing like it, while perl and python3
+# both carry a sub-second clock wherever they are installed.
+# `date +%s` is the floor, and whole seconds are too coarse to attribute
+# anything, so a run that falls back to it says so rather than reporting
+# a column of zeroes as if they were measurements.
+
+# timing_clock -- the finest clock this machine has, named for now_ms.
+timing_clock() {
+    # What a date without %N prints instead is not the time, and it is not
+    # always obvious either: the letter comes back, or the field width does,
+    # and digits that survive would be taken for a clock. So the answer
+    # counts only when it is digits throughout *and* exactly the three
+    # digits longer than seconds that milliseconds are.
+    _seconds=$(date +%s)
+    _millis=$(date +%s%3N 2>/dev/null)
+
+    case $_millis in
+    '' | *[!0-9]*) ;;
+    *)
+        if [ "${#_millis}" -eq "$((${#_seconds} + 3))" ]; then
+            echo date
+            return 0
+        fi
+        ;;
+    esac
+
+    if command -v perl >/dev/null 2>&1; then
+        echo perl
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        echo python3
+        return 0
+    fi
+
+    echo seconds
+}
+
+# timing_init -- settle the clock before the first measurement.
+#
+# now_ms is called from command substitutions, and what such a subshell
+# learns is lost when it exits: without this, every measurement would look
+# the clock up again, and the caller would never see which one was found.
+timing_init() {
+    TEST_CLOCK=${TEST_CLOCK:-$(timing_clock)}
+    export TEST_CLOCK
+}
+
+# now_ms -- the wall clock in milliseconds.
+now_ms() {
+    case ${TEST_CLOCK:=$(timing_clock)} in
+    date) date +%s%3N ;;
+    perl) perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000' ;;
+    python3) python3 -c 'import time; print(round(time.time() * 1000))' ;;
+    seconds) echo $(($(date +%s) * 1000)) ;;
+    esac
+}
+
+# fmt_duration MILLISECONDS -- `812 ms` below a second, `1.4 s` above it.
+#
+# Two digits of precision throughout, because the durations are read against
+# each other: a check that takes a tenth of the run is what the block is for,
+# and no decision here turns on the third digit.
+fmt_duration() {
+    if [ "$1" -lt 1000 ]; then
+        printf '%d ms' "$1"
+    else
+        printf '%d.%d s' $(($1 / 1000)) $(($1 % 1000 / 100))
+    fi
+}
+
+# timing_report -- render `MILLISECONDS LABEL` lines read from stdin as the
+# comment block a run ends with, the durations right-aligned against each
+# other. Reading from stdin rather than from a variable is what lets a check
+# feed it durations of its own.
+timing_report() {
+    while read -r ms label; do
+        printf '# %8s  %s\n' "$(fmt_duration "$ms")" "$label"
+    done
+}


### PR DESCRIPTION
The suite is one step of one CI job,
so a slow check is invisible inside it:
the job reports that the step took two minutes,
and nothing says which of the checks spent them.

`tests/run` now ends with a block of durations —
the install it opens with, every check it ran, and the run as a whole:

```
# durations
#    1.3 s  install
#    96 ms  05-handbook
#    1.0 s  06-timing
#   460 ms  10-path
#   162 ms  15-tasks
#    2.9 s  20-install
#    2.8 s  30-preexisting
#    3.2 s  40-import
#    3.1 s  50-makefile
#    1.4 s  60-zsh-startup
#   210 ms  65-zsh-startup-profile
#   245 ms  70-git-ssh-remote
#    1.5 s  90-force
#   18.7 s  total
# all checks passed
```

The block comes before the verdict,
so a failing run says where its time went as well as a passing one,
and the total is wall clock rather than the sum of the lines above it —
the throw-away home directory and its seeding are the run's work too.

`TEST_TIMING=0`, or an empty value, drops the block;
a run that will not print the durations does not measure them either.

## The clock

There is no millisecond clock in POSIX `sh`
and none that every machine has,
so `tests/timing.sh` looks for one:
`%N` is GNU `date`'s,
`perl` and `python3` both carry a sub-second clock,
and `date +%s` is the floor.

A `date` without `%N` prints something else back —
the letter, or the field width —
so the answer counts only when it is digits throughout
*and* exactly the three digits longer than seconds that milliseconds are.
Without that second half,
a `date` that drops the conversion but keeps the width
would be taken for a millisecond clock and be wrong by 100×.
A machine left with whole seconds says so above the block
rather than reporting a column of zeroes as if they were measurements.

## Changes

- `tests/timing.sh` — `timing_clock()`, `timing_init()`, `now_ms()`,
  `fmt_duration()` and `timing_report()`,
  sourced by the runner and by the check that covers them.
- `tests/run` — times the install, each check, and the whole run.
- `tests/checks/06-timing.sh` — measures the clock against a `sleep`
  instead of assuming it,
  skipping that one assertion where only a whole-second clock exists,
  and pins the shape of the block.
  It calls the helpers directly, so it runs before the installed checks.
- `handbook/testing/README.md` — a `Durations` section
  and the `06-timing` entry in the check list.

The workflow needs no change:
Actions times its own steps,
and the gap was inside the single step that runs the suite.

Verified locally on Ubuntu with the full suite green,
across all four clocks,
with the off switch, and on a deliberately failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxGBMkuhJARZjtdnz5FAq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxGBMkuhJARZjtdnz5FAq8)_