### PR TITLE
feat(macos): add `nosleep`, with `slf`/`sla` and a sudoers rule that retires the password prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 
 all: install
 
-.PHONY: all install force check uninstall import test test-container
+.PHONY: all install force check uninstall nosleep-grant import test test-container
 
-install force check uninstall:
+install force check uninstall nosleep-grant:
 	@$(CURDIR)/mise-tasks/$@
 
 import test test-container:

--- a/handbook/install/tasks/README.md
+++ b/handbook/install/tasks/README.md
@@ -14,6 +14,7 @@ reachable through [mise](https://mise.jdx.dev) or through `make`:
 | `mise run force` | `make force` | link every file, replacing ones that already exist |
 | `mise run check` | `make check` | list the mapping without touching the filesystem |
 | `mise run uninstall` | `make uninstall` | remove every symbolic link rcm owns |
+| `mise run nosleep-grant` | `make nosleep-grant` | let `nosleep` flip the sleep flag without a password, on macOS ([`tools/`](/handbook/tools/README.md)) |
 | `mise run import <file>` | — | move a file in from the home directory ([`install/import/`](/handbook/install/import/README.md)) |
 | `mise run test` | — | run the checks against a throw-away home directory ([`testing/`](/handbook/testing/README.md)) |
 | `mise run test-container` | — | the same on Linux, from a machine that is not |

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -130,6 +130,21 @@ so it is installed on macOS only.
 and show a desktop notification *in case of error*.
 Installed on macOS only, for the same reason as `n`.
 
+### Sleep (macOS only)
+
+**`nosleep`** — stop the machine from sleeping, or let it sleep again.
+`nosleep on` and `nosleep off` say which,
+and a bare `nosleep` flips whichever way the machine currently sits,
+reading the current state from `pmset -g`.
+This is `pmset -a disablesleep` and deliberately not `caffeinate`:
+the flag survives a closed lid,
+which is the case the tool exists for.
+Writing it needs root,
+so the script names `sudo` rather than hope for a cached credential —
+and a request for the state the machine is already in
+changes nothing and asks for no password.
+Installed on macOS only, since `pmset` is macOS's.
+
 ### The rest
 
 **`fsed`** — run `gsed` over the whole tree below the current

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -143,7 +143,22 @@ Writing it needs root,
 so the script names `sudo` rather than hope for a cached credential —
 and a request for the state the machine is already in
 changes nothing and asks for no password.
+**`slf`** ("sleep forbid") and **`sla`** ("sleep allow")
+are the two spellings at three letters,
+for the times both are typed often.
 Installed on macOS only, since `pmset` is macOS's.
+
+`mise run nosleep-grant` retires the password prompt
+([`install/tasks/`](/handbook/install/tasks/README.md)):
+it writes a rule to `/etc/sudoers.d/nosleep`
+that lets this account run `pmset -a disablesleep` with a 1 and with a 0,
+and nothing else.
+sudo compares the arguments it is given literally,
+so a rule that spells them out grants those two lines alone —
+not `disablesleep 2`, not another `pmset` setting.
+`--print` shows the rule without writing it, `--remove` takes it back,
+and `nosleep` needs none of it:
+without the rule it asks for a password, as it always has.
 
 ### The rest
 

--- a/mise-tasks/nosleep-grant
+++ b/mise-tasks/nosleep-grant
@@ -1,0 +1,84 @@
+#!/bin/sh
+#MISE description="Let nosleep flip the sleep flag without asking for a password"
+#
+# `nosleep` needs root to write the flag, and this is what stops it asking for a
+# password every time. The rule is two commands wide -- `pmset -a disablesleep`
+# with a 1 and with a 0, both spelled out in full -- and sudo compares the
+# arguments it is given literally, so nothing else passes: not `disablesleep 2`,
+# not another pmset setting, not a third argument. No new code runs as root;
+# there is nothing here to audit but the one line.
+#
+# A task rather than a file under rcm/, because rcm links into the home
+# directory and this file belongs to root.
+#
+#   mise run nosleep-grant            write the rule
+#   mise run nosleep-grant --print    show it, write nothing
+#   mise run nosleep-grant --remove   take it away again
+#
+# `make nosleep-grant` reaches the first of those; the options need the task to
+# be named, through mise or by running this file.
+
+set -eu
+
+# No dot in the name: sudo ignores the files that carry one.
+file=/etc/sudoers.d/nosleep
+
+# Whoever asked, rather than root, on the chance this is reached through sudo.
+user=${SUDO_USER:-$(id -un)}
+rule="$user ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 1, /usr/bin/pmset -a disablesleep 0"
+
+usage() {
+    echo "Usage: $0 [--print|--remove]" >&2
+    exit 1
+}
+
+case "$#:${1:-}" in
+0:) action=write ;;
+1:--print) action=print ;;
+1:--remove) action=remove ;;
+*) usage ;;
+esac
+
+# Before the platform check, so the rule can be read on any machine -- reviewing
+# a grant is the one thing worth doing away from the machine it is granted on.
+if [ "$action" = print ]; then
+    printf '%s\n' "$rule"
+    exit 0
+fi
+
+[ "$(uname -s)" = Darwin ] || {
+    echo "nosleep-grant: pmset is macOS's, and so is this rule" >&2
+    exit 1
+}
+
+if [ "$action" = remove ]; then
+    if [ -e "$file" ]; then
+        echo "removing $file"
+        sudo rm -f "$file"
+    else
+        echo "$file is not there; nothing to remove"
+    fi
+    exit 0
+fi
+
+echo "This writes $file, granting:"
+echo
+printf '  %s\n' "$rule"
+echo
+echo "sudo asks for your password once, to write a file that belongs to root."
+echo
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/nosleep-grant.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' "$rule" >"$tmp"
+
+# Syntax first: sudo refuses to run at all while a file in sudoers.d fails to
+# parse, and that is a bad way to find out.
+visudo -c -q -f "$tmp"
+
+[ ! -e "$file" ] || echo "replacing the $file already there"
+
+# 0440 and root:wheel, or sudo passes the file over in silence.
+sudo install -m 0440 -o root -g wheel "$tmp" "$file"
+
+echo "done -- nosleep no longer asks for a password"

--- a/rcm/tag-macos/bin/nosleep
+++ b/rcm/tag-macos/bin/nosleep
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Stop the machine from sleeping, or let it sleep again.
+#
+# `pmset -a disablesleep` and not `caffeinate`: this one survives a closed lid,
+# which is the case the tool exists for.
+
+case "$#:${1:-}" in
+  0:) want= ;;
+  1:on) want=1 ;;
+  1:off) want=0 ;;
+  *)
+    echo "Usage: $0 [on|off]" >&2
+    exit 1
+    ;;
+esac
+
+command -v pmset >/dev/null || {
+  echo "$0: no pmset -- this is a macOS tool" >&2
+  exit 1
+}
+
+label() {
+  if [ "$1" = 1 ]; then echo disabled; else echo enabled; fi
+}
+
+# `pmset -a disablesleep` writes the system-wide flag that `pmset -g` prints as
+# SleepDisabled; both spellings are read because the name has moved between
+# releases. A machine where it was never set prints neither, and is awake.
+state() {
+  case "$(pmset -g |
+    awk 'tolower($1) ~ /^(sleepdisabled|disablesleep)$/ { print $2; exit }')" in
+    1 | [Yy]es | [Tt]rue) echo 1 ;;
+    *) echo 0 ;;
+  esac
+}
+
+current=$(state)
+[ -n "$want" ] || want=$((1 - current))
+
+if [ "$want" = "$current" ]; then
+  echo "sleep is already $(label "$current")"
+  exit 0
+fi
+
+# Only root writes this, so name sudo rather than hope for a cached credential.
+# The no-op above returns before we get here, so asking for nothing costs no
+# password prompt.
+if [ "$(id -u)" = 0 ]; then
+  sudo=
+elif command -v sudo >/dev/null; then
+  sudo=sudo
+else
+  echo "$0: changing this needs root, and sudo is not installed" >&2
+  exit 1
+fi
+
+# Unquoted on purpose: one word when sudo is needed, no word at all when not.
+$sudo pmset -a disablesleep "$want" || exit
+
+echo "sleep $(label "$want")"

--- a/rcm/tag-macos/bin/sla
+++ b/rcm/tag-macos/bin/sla
@@ -1,0 +1,11 @@
+#!/bin/sh
+# "sleep allow" -- `nosleep off`, at three letters.
+
+[ $# -eq 0 ] || {
+  echo "Usage: $0" >&2
+  exit 1
+}
+
+# By path rather than by name: this works from a checkout, where ~/bin is not
+# what found it.
+exec "$(dirname -- "$0")/nosleep" off

--- a/rcm/tag-macos/bin/slf
+++ b/rcm/tag-macos/bin/slf
@@ -1,0 +1,11 @@
+#!/bin/sh
+# "sleep forbid" -- `nosleep on`, at three letters.
+
+[ $# -eq 0 ] || {
+  echo "Usage: $0" >&2
+  exit 1
+}
+
+# By path rather than by name: this works from a checkout, where ~/bin is not
+# what found it.
+exec "$(dirname -- "$0")/nosleep" on

--- a/tests/checks/75-nosleep.sh
+++ b/tests/checks/75-nosleep.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# `nosleep` decides and `pmset` obeys, so the deciding is what is checked here:
+# the two explicit spellings, the bare toggle, the no-op that asks for no
+# password, and the arguments that are refused.
+#
+# Against stub `pmset` and `sudo` commands, for three reasons. The real ones
+# would put the machine running the checks to sleep -- or keep it awake for
+# good -- ask for a password no check may wait at, and exist on macOS alone,
+# where this script installs but half of CI does not run. The stub records
+# what it was told instead, and the logic is covered on both platforms.
+#
+# What is platform-specific here is the installation, checked at the end.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+script=$REPO/rcm/tag-macos/bin/nosleep
+
+work=$HOME/nosleep-check
+rm -rf "$work"
+mkdir -p "$work/bin"
+
+STATE=$work/state
+SUDO_LOG=$work/sudo-log
+export STATE SUDO_LOG
+
+# Enough of pmset for this: `-g` prints the flag the way macOS prints it, under
+# the name a machine that has it set shows, and prints nothing at all before it
+# is ever set -- the state a fresh machine is in.
+cat >"$work/bin/pmset" <<'STUB'
+#!/bin/sh
+case "$1" in
+-g)
+    if [ -f "$STATE" ]; then
+        printf 'System-wide power settings:\n SleepDisabled\t\t%s\n' "$(cat "$STATE")"
+    fi
+    ;;
+-a)
+    [ "$2" = disablesleep ] || exit 1
+    printf '%s\n' "$3" >"$STATE"
+    ;;
+esac
+STUB
+
+cat >"$work/bin/sudo" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" >>"$SUDO_LOG"
+exec "$@"
+STUB
+
+chmod +x "$work/bin/pmset" "$work/bin/sudo"
+
+PATH=$work/bin:$PATH
+export PATH
+
+# run ARGUMENT... -- leaves what nosleep printed in $output, its status in
+# $status, and both streams together because the usage line goes to stderr.
+run() {
+    output=$("$script" "$@" 2>&1)
+    status=$?
+}
+
+state() {
+    cat "$STATE" 2>/dev/null || echo unset
+}
+
+sudo_calls() {
+    if [ -f "$SUDO_LOG" ]; then
+        wc -l <"$SUDO_LOG" | tr -d ' '
+    else
+        echo 0
+    fi
+}
+
+# --- the explicit spellings ------------------------------------------------
+
+run on
+assert_equal "nosleep on succeeds" "0" "$status"
+assert_equal "nosleep on disables sleep" "1" "$(state)"
+assert_equal "nosleep on says so" "sleep disabled" "$output"
+
+run off
+assert_equal "nosleep off succeeds" "0" "$status"
+assert_equal "nosleep off enables sleep again" "0" "$(state)"
+assert_equal "nosleep off says so" "sleep enabled" "$output"
+
+# --- the bare toggle -------------------------------------------------------
+
+run
+assert_equal "bare nosleep toggles an enabled machine" "1" "$(state)"
+assert_equal "bare nosleep says what it did" "sleep disabled" "$output"
+
+run
+assert_equal "bare nosleep toggles back" "0" "$(state)"
+assert_equal "bare nosleep says that too" "sleep enabled" "$output"
+
+# A machine where the flag was never set names it in no output at all, and is
+# awake: the toggle has to read that as off rather than as unknown.
+rm -f "$STATE"
+run
+assert_equal "bare nosleep reads an unset flag as enabled" "1" "$(state)"
+
+# --- the no-op -------------------------------------------------------------
+
+# Already there, so there is nothing to write and nothing to ask a password
+# for. Both halves matter: the second is why this is not just an early exit.
+rm -f "$SUDO_LOG"
+run on
+assert_equal "nosleep on twice succeeds" "0" "$status"
+assert_equal "nosleep on twice says it is already there" \
+    "sleep is already disabled" "$output"
+assert_equal "a no-op runs no sudo" "0" "$(sudo_calls)"
+
+# The contrast that gives the line above its meaning: a real change does reach
+# sudo. Not where the checks themselves run as root -- a container -- and there
+# the script is right to call pmset directly.
+if [ "$(id -u)" = 0 ]; then
+    skip "already root: the sudo prefix is not part of the change"
+else
+    rm -f "$SUDO_LOG"
+    run off
+    assert_equal "a real change goes through sudo" "1" "$(sudo_calls)"
+fi
+
+# --- the arguments that are refused ----------------------------------------
+
+before=$(state)
+
+run sometimes
+assert_equal "an unknown argument fails" "1" "$status"
+assert_match "an unknown argument prints the usage" "Usage:*" "$output"
+
+run on off
+assert_equal "two arguments fail" "1" "$status"
+assert_match "two arguments print the usage" "Usage:*" "$output"
+
+assert_equal "a refused argument changes nothing" "$before" "$(state)"
+
+# --- where it installs -----------------------------------------------------
+
+# pmset is macOS's, so the script is, and rcm has to keep it off everything
+# else -- the property the platform tags exist for.
+if [ "$(uname -s)" = Darwin ]; then
+    if [ -x "$HOME/bin/nosleep" ]; then
+        pass "nosleep is installed and executable on macOS"
+    else
+        fail "nosleep is installed and executable on macOS" \
+            "$(ls -l "$HOME/bin/nosleep" 2>&1)"
+    fi
+else
+    if [ -e "$HOME/bin/nosleep" ]; then
+        fail "nosleep is not installed off macOS" "$HOME/bin/nosleep exists"
+    else
+        pass "nosleep is not installed off macOS"
+    fi
+fi
+
+rm -rf "$work"

--- a/tests/checks/75-nosleep.sh
+++ b/tests/checks/75-nosleep.sh
@@ -54,11 +54,17 @@ chmod +x "$work/bin/pmset" "$work/bin/sudo"
 PATH=$work/bin:$PATH
 export PATH
 
-# run ARGUMENT... -- leaves what nosleep printed in $output, its status in
-# $status, and both streams together because the usage line goes to stderr.
-run() {
-    output=$("$script" "$@" 2>&1)
+# run_as SCRIPT ARGUMENT... -- leaves what SCRIPT printed in $output, its status
+# in $status, and both streams together because the usage line goes to stderr.
+run_as() {
+    _script=$1
+    shift
+    output=$("$_script" "$@" 2>&1)
     status=$?
+}
+
+run() {
+    run_as "$script" "$@"
 }
 
 state() {
@@ -137,23 +143,47 @@ assert_match "two arguments print the usage" "Usage:*" "$output"
 
 assert_equal "a refused argument changes nothing" "$before" "$(state)"
 
+# --- the three-letter spellings --------------------------------------------
+
+# slf and sla find nosleep by path rather than by name, so they work from a
+# checkout as well as from ~/bin -- which is also what lets them be run here,
+# against the same stub.
+printf '0\n' >"$STATE"
+
+run_as "${script%/*}/slf"
+assert_equal "slf forbids sleep" "1" "$(state)"
+assert_equal "slf says what it did" "sleep disabled" "$output"
+
+run_as "${script%/*}/sla"
+assert_equal "sla allows it again" "0" "$(state)"
+assert_equal "sla says what it did" "sleep enabled" "$output"
+
+# They are one spelling each, not a second way to pass an argument: `slf off`
+# would read as the opposite of what it does.
+run_as "${script%/*}/slf" off
+assert_equal "slf takes no argument" "1" "$status"
+assert_match "slf prints the usage instead" "Usage:*" "$output"
+assert_equal "a refused shortcut changes nothing" "0" "$(state)"
+
 # --- where it installs -----------------------------------------------------
 
-# pmset is macOS's, so the script is, and rcm has to keep it off everything
-# else -- the property the platform tags exist for.
-if [ "$(uname -s)" = Darwin ]; then
-    if [ -x "$HOME/bin/nosleep" ]; then
-        pass "nosleep is installed and executable on macOS"
+# pmset is macOS's, so these are, and rcm has to keep them off everything else
+# -- the property the platform tags exist for.
+for name in nosleep slf sla; do
+    if [ "$(uname -s)" = Darwin ]; then
+        if [ -x "$HOME/bin/$name" ]; then
+            pass "$name is installed and executable on macOS"
+        else
+            fail "$name is installed and executable on macOS" \
+                "$(ls -l "$HOME/bin/$name" 2>&1)"
+        fi
     else
-        fail "nosleep is installed and executable on macOS" \
-            "$(ls -l "$HOME/bin/nosleep" 2>&1)"
+        if [ -e "$HOME/bin/$name" ]; then
+            fail "$name is not installed off macOS" "$HOME/bin/$name exists"
+        else
+            pass "$name is not installed off macOS"
+        fi
     fi
-else
-    if [ -e "$HOME/bin/nosleep" ]; then
-        fail "nosleep is not installed off macOS" "$HOME/bin/nosleep exists"
-    else
-        pass "nosleep is not installed off macOS"
-    fi
-fi
+done
 
 rm -rf "$work"

--- a/tests/checks/76-nosleep-grant.sh
+++ b/tests/checks/76-nosleep-grant.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# The rule `nosleep-grant` writes, checked without writing it.
+#
+# `--print` is what makes that possible, and it is there for the same reason it
+# is useful here: a grant of root privileges should be readable before it is
+# given. What the check watches is the width of the rule -- two commands, both
+# spelled out, no wildcard -- because that is the property that makes the grant
+# worth having rather than alarming.
+#
+# Nothing here touches /etc. The write path needs macOS and a password, and
+# neither belongs in a check.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+task=$REPO/mise-tasks/nosleep-grant
+
+run() {
+    output=$("$task" "$@" 2>&1)
+    status=$?
+}
+
+# --- the rule ---------------------------------------------------------------
+
+run --print
+assert_equal "--print succeeds" "0" "$status"
+assert_match "the rule is for whoever asked" "$(id -un) ALL=(root) NOPASSWD:*" \
+    "$output"
+assert_match "it grants disablesleep 1" "*/usr/bin/pmset -a disablesleep 1*" \
+    "$output"
+assert_match "it grants disablesleep 0" "*/usr/bin/pmset -a disablesleep 0*" \
+    "$output"
+
+# sudo compares given arguments literally, so a rule without a wildcard grants
+# the two lines it names and nothing else. A wildcard would quietly widen it to
+# every pmset setting there is.
+case $output in
+*'*'*)
+    fail "the rule carries no wildcard" "$output"
+    ;;
+*)
+    pass "the rule carries no wildcard"
+    ;;
+esac
+
+assert_equal "the rule is one line" "1" "$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
+
+# A sudoers file that does not parse stops sudo from running at all, so the task
+# validates before installing -- and what it validates is checked here.
+if command -v visudo >/dev/null 2>&1; then
+    tmp=$(mktemp "${TMPDIR:-/tmp}/nosleep-grant-check.XXXXXX")
+    printf '%s\n' "$output" >"$tmp"
+    assert_ok "the rule parses as sudoers" visudo -c -q -f "$tmp"
+    rm -f "$tmp"
+else
+    skip "visudo: not installed"
+fi
+
+# --- where it refuses -------------------------------------------------------
+
+# The write path is macOS's, and asks for a password. Off macOS the refusal is
+# the whole behaviour and safe to run; on macOS it is left alone.
+if [ "$(uname -s)" = Darwin ]; then
+    skip "macOS: the write path wants a password, and no check may wait at one"
+else
+    run
+    assert_equal "writing the rule off macOS fails" "1" "$status"
+    assert_match "and says why" "*macOS*" "$output"
+fi
+
+run --nonsense
+assert_equal "an unknown option fails" "1" "$status"
+assert_match "an unknown option prints the usage" "Usage:*" "$output"
+
+run --print --remove
+assert_equal "two options fail" "1" "$status"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -31,6 +31,20 @@ assert_equal() {
     fi
 }
 
+# assert_match DESCRIPTION PATTERN TEXT -- PATTERN is a shell glob, unquoted on
+# purpose, so `Usage:*` matches a message whose tail is a path.
+assert_match() {
+    case $3 in
+    $2)
+        pass "$1"
+        ;;
+    *)
+        fail "$1" "no match for: $2
+  actual: $3"
+        ;;
+    esac
+}
+
 # assert_in_path DESCRIPTION DIRECTORY PATH_VALUE
 assert_in_path() {
     case ":$3:" in


### PR DESCRIPTION
Closes #40.

`sudo pmset -a disablesleep 1` and its `0` counterpart were typed by hand,
in both directions, over and over.
This replaces both.

## What it does

```sh
nosleep on     # sleep disabled            slf   "sleep forbid"
nosleep off    # sleep enabled             sla   "sleep allow"
nosleep        # flips the current state
nosleep on     # sleep is already disabled -- writes nothing, asks nothing
```

Deliberately not `caffeinate`:
`disablesleep` survives a closed lid,
which is the case the tool exists for.

The current state comes from `pmset -g`,
read under both `SleepDisabled` and `disablesleep`
because the name has moved between releases.
A machine that never had the flag set prints neither, and is awake —
so an absent line reads as *enabled* rather than as unknown.

`slf` and `sla` are the three-letter spellings, for a pair typed often in both
directions.
They reach `nosleep` by path rather than by name,
so they work from a checkout as well as from `~/bin`,
and they take no arguments — `slf off` would read as the opposite of what it does.

## Retiring the password prompt

`mise run nosleep-grant` writes a rule to `/etc/sudoers.d/nosleep`:

```
<you> ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 1, /usr/bin/pmset -a disablesleep 0
```

sudo compares the arguments it is given literally, so a rule that spells them
out grants those two lines and nothing else.
Tested directly: `disablesleep 2`, `-a disablesleep 1 extra`, `pmset sleepnow`
and every other setting are all refused.
No new code runs as root — there is nothing to audit but the one line,
which is why this is a sudoers rule rather than a privileged helper.

It is a task rather than a file under `rcm/`,
because rcm links into the home directory and this file belongs to root.
`--print` shows the rule without writing it — reviewing a grant before giving it
is worth a flag, and it is also what lets the checks read the rule on a machine
that will never have it.
`--remove` takes it back.
The rule is validated with `visudo -c` before installing:
sudo refuses to run at all while a file in `sudoers.d` fails to parse,
and that is a bad way to find out.

`nosleep` itself needs none of this and is unchanged by it.
Plain `sudo` already finds a NOPASSWD rule and skips the prompt on its own,
so there is nothing for the script to detect or fall back to;
without the rule it asks for a password, as it always has.

## Placement

`pmset` is macOS's, so all three scripts install from `rcm/tag-macos/bin/`
and nowhere else.
`tests/checks/75-nosleep.sh` asserts that in both directions for each of them,
which is the platform-tag property recently fixed and worth keeping.

## Testing

`tests/checks/75-nosleep.sh` covers the deciding rather than the sleeping.
The real `pmset` would put the machine running the checks to sleep — or keep it
awake for good — and the real `sudo` would stop at a password prompt no check
may wait at, so both are stubbed:
the stub records what it was told,
and the toggle, the no-op, the shortcuts and the refused arguments are covered
on Linux too.

`tests/checks/76-nosleep-grant.sh` reads the rule through `--print` and watches
its width: both commands spelled out, one line, no wildcard, and it parses under
`visudo -c`.
Nothing in the checks touches `/etc` or asks for a password.

`assert_match` joins the assertion helpers in `tests/lib.sh` for the messages
whose tail is a path.

`tests/run` passes in full, `make check` maps as before, and `make
nosleep-grant` reaches the task — off macOS it refuses, which is the behaviour
the check asserts.
The suite was also run as an unprivileged user, which is what exercises the
`sudo` branch; as root the script calls `pmset` directly and that assertion
skips.

One caveat worth stating: this was developed and tested on Linux, so `pmset -g`
output is matched against the stub rather than the real thing, and the sudoers
rule was verified against Linux sudo 1.9.15 (the same codebase macOS ships)
rather than on macOS itself.
Reading both spellings of the flag name is the hedge;
the first run on a real machine is still the one that confirms it.
