### PR TITLE
fix(`h`): pre-increment the repository counter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,16 +30,19 @@ jobs:
       - uses: actions/checkout@v5
 
       # zsh comes with macOS; on Ubuntu it is installed so that the checks
-      # cover it there too, rather than skipping it.
-      - name: Install rcm
+      # cover it there too, rather than skipping it. The rest is what `h`
+      # drives: its check skips when they are missing, and a job that skips
+      # catches nothing. Which package carries what is
+      # handbook/install/prerequisites/README.md.
+      - name: Install rcm, and what the checks drive
         run: |
           case "$RUNNER_OS" in
           Linux)
             sudo apt-get update
-            sudo apt-get install -y rcm zsh
+            sudo apt-get install -y rcm zsh fd-find parallel
             ;;
           macOS)
-            brew install rcm
+            brew install rcm coreutils fd gnu-sed parallel
             ;;
           esac
 

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -121,6 +121,15 @@ and they run in name order:
   remotes of a throw-away repository
   and leaves every other remote alone,
   through `~/bin` and through the `git sr` alias alike.
+- `75-h`: `h` runs the command in every repository below the current
+  directory, and each line of output says which one it came from.
+  Both halves matter:
+  a run that ends on the first repository prints nothing at all,
+  which is also what an empty directory looks like,
+  so the check names the repositories it expects to hear back from.
+  It links the `fd`, `gsed` and `gsort` names Linux does not ship
+  ([`install/prerequisites/`](/handbook/install/prerequisites/README.md))
+  and skips where the commands behind them are missing too.
 - `90-force`: `mise run force` replaces the files rcm skipped,
   and the scripts are still found afterwards.
   It runs last because it is the one check

--- a/rcm/bin/h
+++ b/rcm/bin/h
@@ -159,7 +159,10 @@ process_git_dirs() {
     local command
 
     local color="${colors[i % ${#colors[@]}]}"
-    ((i++))
+    # An assignment, not `((i++))`: an arithmetic command that evaluates to 0
+    # returns 1, so the very first repository -- where i is still 0 -- ended
+    # the run under the `set -e` above, silently and with no output at all.
+    i=$((i + 1))
 
     command="$(
       printf "cd %q &&" "$line"

--- a/rcm/bin/h
+++ b/rcm/bin/h
@@ -159,10 +159,12 @@ process_git_dirs() {
     local command
 
     local color="${colors[i % ${#colors[@]}]}"
-    # An assignment, not `((i++))`: an arithmetic command that evaluates to 0
-    # returns 1, so the very first repository -- where i is still 0 -- ended
-    # the run under the `set -e` above, silently and with no output at all.
-    i=$((i + 1))
+    # `((++i))`, not `((i++))`: an arithmetic command that evaluates to 0
+    # returns 1, and post-increment evaluates to the value before it -- 0 on
+    # the first repository, which ended the run under the `set -e` above,
+    # silently and with no output at all. Pre-increment evaluates to the value
+    # after, and this counter only ever climbs away from 0.
+    ((++i))
 
     command="$(
       printf "cd %q &&" "$line"

--- a/tests/checks/75-h.sh
+++ b/tests/checks/75-h.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# `h` runs the command in every repository it finds, and says so.
+#
+# The bug this pins was invisible: `h` collected the repositories, then ended
+# on the first one it had to number, under its own `set -e`, printing nothing
+# and exiting 1. Nothing distinguishes that from a directory with no
+# repositories below it, which is why a check has to name the repositories it
+# expects to hear back from.
+#
+# The tools `h` drives are not this repository's to install
+# (`install/prerequisites/`), so the check builds the two links a Linux box
+# needs -- the GNU commands are there under their plain names -- and skips
+# where even those are missing.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+work=$HOME/h-check
+rm -rf "$work"
+mkdir -p "$work/shims" "$work/one" "$work/two"
+
+# link_as NAME COMMAND... -- put NAME on the PATH, from the first COMMAND that
+# exists. Returns non-zero when none does, which is the check's skip signal.
+link_as() {
+    _name=$1
+    shift
+
+    if command -v "$_name" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    for _candidate in "$@"; do
+        _found=$(command -v "$_candidate" 2>/dev/null) || continue
+        ln -sf "$_found" "$work/shims/$_name"
+        return 0
+    done
+
+    return 1
+}
+
+missing=
+# fd is fdfind on Debian and Ubuntu; gsed and gsort are what macOS calls the
+# GNU commands Linux ships unprefixed.
+link_as fd fdfind || missing="$missing fd"
+link_as gsed sed || missing="$missing gsed"
+link_as gsort sort || missing="$missing gsort"
+command -v parallel >/dev/null 2>&1 || missing="$missing parallel"
+
+if [ -n "$missing" ]; then
+    skip "h: not installed:$missing"
+    exit 0
+fi
+
+PATH="$work/shims:$PATH"
+export PATH
+
+git init -q "$work/one"
+git init -q "$work/two"
+
+output=$(cd "$work" && h --no-color echo scriptlets 2>&1)
+status=$?
+
+assert_equal "h succeeds where there are repositories" 0 "$status"
+
+for repo in one two; do
+    case $output in
+    *"$repo: scriptlets"*)
+        pass "h runs the command in $repo"
+        ;;
+    *)
+        fail "h runs the command in $repo" "$output"
+        ;;
+    esac
+done


### PR DESCRIPTION
`h` prints nothing and exits 1 wherever there is anything to do.

```console
$ h echo hi          # two repositories below the current directory
$ echo $?
1
```

**Why.** An arithmetic command that evaluates to 0 returns 1,
and post-increment evaluates to the value *before* the increment —
0 on the first repository.
[`rcm/bin/h`](https://github.com/krlmlr/scriptlets/blob/main/rcm/bin/h)
runs under `set -euo pipefail`, so `((i++))` ended the run right there;
`h -x` stops after `+ (( i++ ))`.

`((++i))` evaluates to the value *after* the increment,
and this counter only ever climbs away from 0,
so it never returns 1.

Not a bash quirk: zsh 5.9 does the same,
in `h`'s exact shape — a function reading a pipe, under `err_exit` —
and `((++i))` survives in both.
zsh simply does not set that option unless asked.

**The check.**
`tests/checks/75-h.sh` puts two repositories in the throw-away home
and requires both to answer.
It names them rather than asserting a clean exit,
because the failure is silent —
a run that dies on the first repository
looks exactly like a directory with none below it.
Verified both ways: it fails on `main`'s `h` (3 failures) and passes on
this branch's.

**What the check needs.**
The commands `h` drives are not this repository's to install,
so the check links the `fd`, `gsed` and `gsort` names Linux does not
ship — from `fdfind`, `sed` and `sort` — and skips where even those are
missing.
CI installs them on both runners now:
a job that skips catches nothing,
and the run confirms `# 75-h` with three `ok`s on Ubuntu and macOS
alike.

Found while checking the prerequisites documented in #46,
which is documentation only and does not depend on this.
