### PR TITLE
feat: give the sidecar repository a description, and make `bootstrap-private` idempotent

### DIFF
--- a/bootstrap-private
+++ b/bootstrap-private
@@ -1,28 +1,43 @@
 #!/bin/sh
 #
-# Create a private sidecar repository and leave it ready for `mise run install`.
-# See handbook/layout/private/README.md.
+# Create or update the private sidecar repository, and leave it ready for
+# `mise run install`. See handbook/layout/private/README.md.
 #
-# It builds the skeleton of a second dotfiles tree, commits it, creates a
-# private repository on GitHub from that commit, and pushes. The working copy
-# it leaves behind is the clone: no separate checkout step, and `origin` is
-# already set. -n does everything but the parts that touch GitHub and $HOME.
+# Every step is idempotent: it looks at one thing, brings it to the state it
+# should be in, and reports which of the two it found. Running this again --
+# after an interruption, or after it has grown another step -- converges
+# instead of refusing or duplicating, so the script stays a description of the
+# finished state rather than a one-shot.
+#
+# A file that already exists is never rewritten. By the second run it may hold
+# secrets, and nothing here can tell the skeleton it wrote from what you put
+# there afterwards.
+#
+# Adding a step: write one function that inspects, acts only where it must, and
+# reports through `same`, `made` or `changed`. Anything that writes returns
+# early when $dry_run is 1, after reporting what it would have done. Then name
+# the function in the run of steps at the bottom.
 
 set -eu
 
 repo_name=scriptlets-private
+repo_desc="Private sidecar for krlmlr/scriptlets -- the dotfiles that must not be public"
 dry_run=0
 
 REPO=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 
 usage() {
     cat <<EOF
-Usage: bootstrap-private [-n] [-r NAME]
+Usage: bootstrap-private [-n] [-r NAME] [-d DESCRIPTION]
 
-  -r NAME  name of the repository to create (default: $repo_name)
-  -n       dry run: build the skeleton in a temporary directory and print it,
-           touching neither GitHub nor the destination
-  -h       this message
+Creates the private sidecar repository, or brings an existing one up to date.
+Safe to run repeatedly: nothing is duplicated, and no file that already exists
+is rewritten.
+
+  -r NAME         repository name (default: $repo_name)
+  -d DESCRIPTION  its description on GitHub
+  -n              dry run: report what each step would do, change nothing
+  -h              this message
 
 The clone goes to \$SCRIPTLETS_PRIVATE if that is set, and to ~/git/NAME
 otherwise -- the path rcm/rcrc looks in.
@@ -34,10 +49,17 @@ die() {
     exit 1
 }
 
-while getopts 'nr:h' opt; do
+# The three outcomes a step reports. Every step reaches exactly one of them,
+# so the run reads as what changed rather than as what ran.
+same() { printf '  =  %s\n' "$1"; }
+made() { printf '  +  %s\n' "$1"; }
+changed() { printf '  ~  %s\n' "$1"; }
+
+while getopts 'nr:d:h' opt; do
     case $opt in
     n) dry_run=1 ;;
     r) repo_name=$OPTARG ;;
+    d) repo_desc=$OPTARG ;;
     h)
         usage
         exit 0
@@ -56,35 +78,53 @@ dest=${SCRIPTLETS_PRIVATE:-$HOME/git/$repo_name}
 
 command -v git >/dev/null || die "git is required"
 
-if [ "$dry_run" -eq 1 ]; then
-    work=$(mktemp -d "${TMPDIR:-/tmp}/scriptlets-private.XXXXXX")
-    trap 'rm -rf "$work"' EXIT
-else
-    [ ! -e "$dest" ] || die "'$dest' already exists -- remove it, or set \$SCRIPTLETS_PRIVATE elsewhere"
-
+if [ "$dry_run" -eq 0 ]; then
     command -v gh >/dev/null || die "the GitHub CLI is required to create the repository:
        https://cli.github.com -- or create '$repo_name' as a private
        repository by hand and see handbook/layout/private/README.md"
 
     gh auth status >/dev/null 2>&1 || die "gh is not logged in -- run \`gh auth login\`"
-
-    if gh repo view "$repo_name" >/dev/null 2>&1; then
-        die "'$repo_name' already exists on GitHub -- clone it instead:
-       git clone git@github.com:\$(gh api user -q .login)/$repo_name.git '$dest'"
-    fi
-
-    work=$dest
-    mkdir -p "$work"
 fi
 
-# The repository is private in the ordinary sense as well: nothing in it is
-# anyone else's to read, and the permissions here are the ones the installed
-# files have, because rcm links rather than copies.
-chmod 700 "$work"
+# --- the directory ---------------------------------------------------------
 
-mkdir -p "$work/rcm/ssh" "$work/rcm/hooks"
+ensure_dir() {
+    if [ -d "$dest" ]; then
+        same "$dest"
+    else
+        made "$dest"
+        [ "$dry_run" -eq 1 ] && return 0
+        mkdir -p "$dest"
+    fi
 
-cat >"$work/README.md" <<'EOF'
+    # Nothing in a sidecar is anyone else's to read, and rcm links rather than
+    # copies, so these are the permissions the installed files have. Setting
+    # them on every run is what keeps that true after a file is added by hand.
+    [ "$dry_run" -eq 1 ] && return 0
+    chmod 700 "$dest"
+    chmod -R go-rwx "$dest"
+}
+
+# --- the files -------------------------------------------------------------
+
+# Reports, and answers whether the caller should write the file: no for one
+# that is already there, and no in a dry run, where the report is the point.
+seed() {
+    if [ -e "$dest/$1" ]; then
+        same "$1"
+        return 1
+    fi
+
+    made "$1"
+    [ "$dry_run" -eq 1 ] && return 1
+
+    mkdir -p "$dest/$(dirname -- "$1")"
+    return 0
+}
+
+ensure_files() {
+    if seed README.md; then
+        cat >"$dest/README.md" <<'EOF'
 # scriptlets-private
 
 The private sidecar of
@@ -103,12 +143,13 @@ How the two trees merge, what wins a name they both have,
 and what this repository may and may not contain
 is `handbook/layout/private/README.md` in the public repository.
 EOF
+    fi
 
-# The fragment. At the root on purpose: everything under rcm/ is installed, and
-# this tree is walked first, so an `rcm/rcrc` here would land as ~/.rcrc in
-# place of the file that sources this one. The tasks refuse to run if one
-# appears there.
-cat >"$work/rcrc" <<'EOF'
+    # At the root on purpose: everything under rcm/ is installed, and this tree
+    # is walked first, so an `rcm/rcrc` would land as ~/.rcrc in place of the
+    # file that sources this one. The tasks refuse to run if one appears there.
+    if seed rcrc; then
+        cat >"$dest/rcrc" <<'EOF'
 # The sidecar's say in rcm's configuration, sourced by the public repository's
 # rcm/rcrc once it has set DOTFILES_DIRS, UNDOTTED, TAGS and OS_TAG.
 #
@@ -130,8 +171,10 @@ cat >"$work/rcrc" <<'EOF'
 #
 # TAGS="$TAGS work"
 EOF
+    fi
 
-cat >"$work/rcm/bash_secrets" <<'EOF'
+    if seed rcm/bash_secrets; then
+        cat >"$dest/rcm/bash_secrets" <<'EOF'
 # Installed as ~/.bash_secrets, sourced by ~/.bash_aliases -- and so by zsh
 # too, which reads that file through ~/.zshrc.
 #
@@ -140,24 +183,30 @@ cat >"$work/rcm/bash_secrets" <<'EOF'
 #
 # export SOME_API_TOKEN=...
 EOF
+    fi
 
-cat >"$work/rcm/gitconfig.user" <<'EOF'
+    if seed rcm/gitconfig.user; then
+        cat >"$dest/rcm/gitconfig.user" <<'EOF'
 # Installed as ~/.gitconfig.user, pulled in by the [include] section of
 # ~/.gitconfig.
 #
 # [user]
 # 	email = you@example.com
 EOF
+    fi
 
-cat >"$work/rcm/Rprofile.private" <<'EOF'
+    if seed rcm/Rprofile.private; then
+        cat >"$dest/rcm/Rprofile.private" <<'EOF'
 # Installed as ~/.Rprofile.private, sourced by ~/.Rprofile if it is there.
 #
 # options(
 #   some.private.option = "..."
 # )
 EOF
+    fi
 
-cat >"$work/rcm/ssh/config-private" <<'EOF'
+    if seed rcm/ssh/config-private; then
+        cat >"$dest/rcm/ssh/config-private" <<'EOF'
 # Installed as ~/.ssh/config-private, pulled in by the `Include config-private`
 # in ~/.ssh/config.
 #
@@ -165,9 +214,11 @@ cat >"$work/rcm/ssh/config-private" <<'EOF'
 #   HostName internal.example.com
 #   User you
 EOF
+    fi
 
-# rcm runs a tree's own hooks, and never installs the directory they are in.
-cat >"$work/rcm/hooks/post-up" <<'EOF'
+    # rcm runs a tree's own hooks, and never installs the directory they sit in.
+    if seed rcm/hooks/post-up; then
+        cat >"$dest/rcm/hooks/post-up" <<'EOF'
 #!/bin/sh
 # Run by rcm after it has linked this tree, from the directory it sits in.
 #
@@ -181,45 +232,190 @@ set -eu
 cd -- "$(dirname -- "$0")/../.."
 chmod -R go-rwx .
 EOF
-chmod +x "$work/rcm/hooks/post-up"
+        chmod +x "$dest/rcm/hooks/post-up"
+    fi
+}
 
-# `git init -b` needs git 2.28; setting HEAD by hand works on every version,
-# and is not at the mercy of init.defaultBranch either.
-git -C "$work" init -q
-git -C "$work" symbolic-ref HEAD refs/heads/main
-git -C "$work" add -A
-git -C "$work" commit -q -m "Initial commit"
+# --- the git repository ----------------------------------------------------
+
+ensure_git() {
+    if [ -d "$dest/.git" ]; then
+        same "git repository"
+        return 0
+    fi
+
+    made "git repository, on main"
+    [ "$dry_run" -eq 1 ] && return 0
+
+    # `git init -b` needs git 2.28; setting HEAD by hand works on every version,
+    # and is not at the mercy of init.defaultBranch either.
+    git -C "$dest" init -q
+    git -C "$dest" symbolic-ref HEAD refs/heads/main
+}
+
+ensure_commit() {
+    if [ "$dry_run" -eq 1 ]; then
+        [ -d "$dest/.git" ] || made "commit \"Initial commit\""
+        return 0
+    fi
+
+    git -C "$dest" add -A
+
+    if git -C "$dest" diff --cached --quiet; then
+        same "commit (nothing staged)"
+        return 0
+    fi
+
+    git -C "$dest" var GIT_AUTHOR_IDENT >/dev/null 2>&1 ||
+        die "git has no identity here -- set user.name and user.email first"
+
+    if git -C "$dest" rev-parse --verify -q HEAD >/dev/null; then
+        message="Update the sidecar skeleton"
+    else
+        message="Initial commit"
+    fi
+
+    git -C "$dest" commit -q -m "$message"
+    made "commit \"$message\""
+}
+
+# --- the repository on GitHub ----------------------------------------------
+
+ensure_github() {
+    if [ "$dry_run" -eq 1 ]; then
+        if ! command -v gh >/dev/null; then
+            same "GitHub repository (not checked: no gh)"
+        elif gh repo view "$repo_name" >/dev/null 2>&1; then
+            same "GitHub repository $repo_name"
+        else
+            made "GitHub repository $repo_name, private"
+        fi
+        return 0
+    fi
+
+    if gh repo view "$repo_name" >/dev/null 2>&1; then
+        same "GitHub repository $(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner)"
+        return 0
+    fi
+
+    gh repo create "$repo_name" --private --description "$repo_desc" >/dev/null
+    made "GitHub repository $(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner), private"
+}
+
+# Separate from creating it, because the description is the one property this
+# script owns on a repository it did not create: a run that changes -d changes
+# it on GitHub, and a run that does not leaves it alone.
+ensure_description() {
+    if [ "$dry_run" -eq 1 ]; then
+        command -v gh >/dev/null || return 0
+
+        # A repository that is not there yet is created with the description
+        # already on it, and the step above is what reports that.
+        gh repo view "$repo_name" >/dev/null 2>&1 || return 0
+
+        current=$(gh repo view "$repo_name" --json description -q .description)
+        if [ "$current" = "$repo_desc" ]; then
+            same "description"
+        else
+            changed "description: $repo_desc"
+        fi
+        return 0
+    fi
+
+    current=$(gh repo view "$repo_name" --json description -q .description)
+
+    if [ "$current" = "$repo_desc" ]; then
+        same "description"
+        return 0
+    fi
+
+    gh repo edit "$repo_name" --description "$repo_desc" >/dev/null
+    changed "description: $repo_desc"
+}
+
+# --- the remote, and the push ----------------------------------------------
+
+ensure_remote() {
+    if [ "$dry_run" -eq 1 ]; then
+        if [ -d "$dest/.git" ] && git -C "$dest" remote get-url origin >/dev/null 2>&1; then
+            same "remote origin"
+        else
+            made "remote origin"
+        fi
+        return 0
+    fi
+
+    url=$(gh repo view "$repo_name" --json sshUrl -q .sshUrl)
+
+    if existing=$(git -C "$dest" remote get-url origin 2>/dev/null); then
+        # Not rewritten: a remote pointing somewhere else is a decision, and
+        # pushing to it would be this script acting on a guess about which.
+        if [ "$existing" = "$url" ]; then
+            same "remote origin"
+        else
+            die "origin is '$existing', not '$url' --
+       point it where you mean it to go, or drop it and run this again"
+        fi
+        return 0
+    fi
+
+    # SSH, matching what `git ssh-remote` converts every other remote to.
+    git -C "$dest" remote add origin "$url"
+    made "remote origin -> $url"
+}
+
+ensure_push() {
+    if [ "$dry_run" -eq 1 ]; then
+        made "push of main to origin"
+        return 0
+    fi
+
+    local_sha=$(git -C "$dest" rev-parse main)
+    remote_sha=$(git -C "$dest" ls-remote origin refs/heads/main 2>/dev/null | cut -f1)
+
+    # -u regardless: an already-pushed branch may still have no upstream, and
+    # setting one twice costs nothing.
+    git -C "$dest" push -q -u origin main
+
+    if [ "$local_sha" = "$remote_sha" ]; then
+        same "push (origin already has main)"
+    else
+        made "push of main to origin"
+    fi
+}
+
+# --- the run ---------------------------------------------------------------
 
 if [ "$dry_run" -eq 1 ]; then
-    echo "# dry run -- nothing was created on GitHub, and $dest was not touched"
-    echo
-    echo "# the skeleton, committed as \"Initial commit\":"
-    git -C "$work" ls-files | sed 's/^/  /'
-    echo
-    echo "# it would be pushed with:"
-    echo "  gh repo create $repo_name --private --source=$dest --remote=origin --push"
+    echo "# dry run: nothing below is carried out"
+fi
+
+echo "# $dest"
+echo "#   + created   = already so   ~ updated"
+echo
+
+ensure_dir
+ensure_files
+ensure_git
+ensure_commit
+ensure_github
+ensure_description
+ensure_remote
+ensure_push
+
+if [ "$dry_run" -eq 1 ]; then
     exit 0
 fi
 
-gh repo create "$repo_name" --private --source="$work" --remote=origin --push
-
-# --push leaves the branch pushed; this is what makes it tracked, so that a
-# later bare `git push` from the clone knows where to go.
-git -C "$work" push -q -u origin main
-
-url=$(gh repo view "$repo_name" --json url -q .url 2>/dev/null || true)
-
 echo
-echo "# created:  ${url:-$(git -C "$work" remote get-url origin)}"
-echo "# cloned:   $work"
+echo "# $(gh repo view "$repo_name" --json url -q .url)"
 
-# What the sidecar will actually install, resolved the way an install resolves
-# it: the destinations below come from the sidecar rather than the public tree.
+# What the sidecar adds, resolved the way an install resolves it.
 if command -v lsrc >/dev/null; then
-    echo "# it adds:"
-    RCRC="$REPO/rcm/rcrc" SCRIPTLETS_PRIVATE="$work" \
-        lsrc -d "$work/rcm" -d "$REPO/rcm" 2>/dev/null |
-        grep -F ":$work/" | cut -d: -f1 | sed 's/^/  /'
+    echo "# it installs:"
+    RCRC="$REPO/rcm/rcrc" SCRIPTLETS_PRIVATE="$dest" \
+        lsrc -d "$dest/rcm" -d "$REPO/rcm" 2>/dev/null |
+        grep -F ":$dest/" | cut -d: -f1 | sed 's/^/  /'
 fi
 
 cat <<EOF
@@ -230,5 +426,5 @@ Next:
   mise run install    # link both trees into the home directory
 
 Put a secret in it by editing the file it belongs in, then commit and push
-from $work as usual.
+from $dest. Running this script again is safe: it will leave that file alone.
 EOF

--- a/handbook/layout/private/README.md
+++ b/handbook/layout/private/README.md
@@ -29,29 +29,50 @@ and [`mise-tasks/lib.sh`](/mise-tasks/lib.sh), for the tasks
 
 ## Creating one
 
-[`bootstrap-private`](/bootstrap-private) does it in one run:
-it writes the skeleton, commits it as `Initial commit`,
-creates a private GitHub repository from that commit and pushes it,
-and leaves the working copy behind as the clone.
+[`bootstrap-private`](/bootstrap-private) writes the skeleton,
+commits it, creates the repository private on GitHub with a description,
+adds `origin` and pushes,
+leaving the working copy behind as the clone:
 
 ```sh
-./bootstrap-private -n     # print the skeleton, create nothing
-./bootstrap-private        # create it
+./bootstrap-private -n     # report what each step would do, change nothing
+./bootstrap-private        # do it
 ```
 
 It needs the [GitHub CLI](https://cli.github.com) logged in
-([`install/prerequisites/`](/handbook/install/prerequisites/README.md)),
-and `-r` names the repository where `scriptlets-private` is taken.
-It refuses rather than merge into something that already exists:
-a destination directory that is there,
-or a repository of that name already on GitHub,
-each stop it with the command that would have been right instead.
+([`install/prerequisites/`](/handbook/install/prerequisites/README.md)).
+`-r` names the repository where `scriptlets-private` is taken,
+and `-d` gives it a description —
+the one property the script keeps in step on a repository it did not
+create, so a later run with a different `-d` changes it on GitHub
+and a run without one leaves it alone.
 Without `gh` the same end state is a private repository created by
 hand, cloned to the path above,
-and the skeleton written into it — `-n` prints the file list.
+and the skeleton written into it; `-n` lists the files.
 
 The skeleton is empty of secrets and installs cleanly as it stands:
 every file in it is comments, saying what belongs there.
+
+**Every step is idempotent, and says which of two things it found.**
+A step brings one thing to the state it should be in and reports it as
+created, already so, or updated,
+so a run reads as what changed rather than as what ran.
+Running the script again therefore converges —
+after an interruption, on a machine where half of it is already done,
+or once it has grown another step —
+and this is the property to preserve when adding one:
+inspect first, act only where the state differs.
+
+**No file that exists is ever rewritten.**
+By the second run a file may hold the secrets it was created to hold,
+and nothing in the script can tell what it wrote
+from what was put there afterwards.
+The same run reports such a file as already present and moves on,
+which is also why a half-finished first attempt can simply be rerun.
+`origin` is the one thing a rerun will not adjust:
+a remote pointing somewhere else is a decision,
+and pushing to it would be the script guessing which.
+It stops and says so instead.
 
 ## What goes in it
 

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -72,6 +72,17 @@ and they run in name order:
   that none of them reaches rcm on its own
   and so decides for itself which trees to act on
   ([`install/tasks/`](/handbook/install/tasks/README.md)).
+- `27-bootstrap-private`: `bootstrap-private` creates a sidecar
+  and converges on a re-run:
+  a dry run changes nothing and names every file it would write,
+  the first run commits the skeleton on `main` as `Initial commit`
+  with the fragment at the root and the hook executable,
+  and a settled run creates nothing,
+  invents no commit,
+  and leaves a file edited by hand exactly as it was.
+  GitHub is a stub answering the few `gh` calls the script makes,
+  so a step that reaches for `gh` in a new way fails here
+  rather than silently going untested.
 - `30-preexisting`: an account that came with its own
   `~/.bash_profile` keeps it,
   and `make force` is what makes the scripts reachable there.

--- a/tests/checks/27-bootstrap-private.sh
+++ b/tests/checks/27-bootstrap-private.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+# `bootstrap-private` creates the private sidecar repository, and converges on
+# a re-run rather than refusing or duplicating
+# (handbook/layout/private/README.md).
+#
+# Idempotency is the property that has to survive the script growing another
+# step, and the only way to see it is to run the thing twice and compare. The
+# second run must report no creation at all, and must leave a file that was
+# edited by hand exactly as it was -- by then it holds secrets.
+#
+# GitHub is stood in for by the stub below, which answers only the handful of
+# `gh` calls the script makes. It is a stub, so it pins the calls as much as
+# the behaviour: a step that reaches for gh in a new way fails here loudly,
+# which is the point at which to decide whether the stub or the step is wrong.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/scriptlets-bootstrap.XXXXXX")
+dest=$work/side
+
+mkdir "$work/bin"
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+set -eu
+mkdir -p "$GH_STATE"
+
+# The flag values the script passes, read positionally rather than parsed.
+flag() {
+    _want=$1
+    shift
+    _prev=
+    for _a in "$@"; do
+        [ "$_prev" = "$_want" ] && { printf '%s' "$_a"; return 0; }
+        _prev=$_a
+    done
+}
+
+case "${1:-} ${2:-}" in
+"auth status") exit 0 ;;
+"repo view")
+    [ -f "$GH_STATE/exists" ] || exit 1
+    case "$(flag -q "$@")" in
+    .nameWithOwner) echo "stub/$3" ;;
+    .description) cat "$GH_STATE/description" 2>/dev/null || true; echo ;;
+    .sshUrl) echo "$GH_STATE/remote.git" ;;
+    .url) echo "https://github.example/stub/$3" ;;
+    esac
+    exit 0
+    ;;
+"repo create")
+    [ -f "$GH_STATE/exists" ] && exit 1
+    printf '%s' "$(flag --description "$@")" >"$GH_STATE/description"
+    git init -q --bare "$GH_STATE/remote.git"
+    : >"$GH_STATE/exists"
+    exit 0
+    ;;
+"repo edit")
+    printf '%s' "$(flag --description "$@")" >"$GH_STATE/description"
+    exit 0
+    ;;
+esac
+
+echo "gh stub: unhandled call: $*" >&2
+exit 1
+STUB
+chmod +x "$work/bin/gh"
+
+PATH=$work/bin:$PATH
+GH_STATE=$work/state
+SCRIPTLETS_PRIVATE=$dest
+export PATH GH_STATE SCRIPTLETS_PRIVATE
+
+# The throw-away home has no git identity, and neither does a CI runner: the
+# repository's ~/.gitconfig only carries one for an account with a tag.
+GIT_AUTHOR_NAME=check
+GIT_AUTHOR_EMAIL=check@example
+GIT_COMMITTER_NAME=check
+GIT_COMMITTER_EMAIL=check@example
+export GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+
+# --- the dry run changes nothing -------------------------------------------
+
+if plan=$("$REPO/bootstrap-private" -n 2>&1); then
+    pass "a dry run on nothing succeeds"
+else
+    fail "a dry run on nothing succeeds" "$plan"
+fi
+
+if [ -e "$dest" ]; then
+    fail "a dry run creates nothing" "$dest exists"
+else
+    pass "a dry run creates nothing"
+fi
+
+missing=
+for name in README.md rcrc rcm/bash_secrets rcm/gitconfig.user \
+    rcm/Rprofile.private rcm/ssh/config-private rcm/hooks/post-up; do
+    printf '%s\n' "$plan" | grep -qF "+  $name" || missing="$missing $name"
+done
+
+if [ -z "$missing" ]; then
+    pass "the plan names every file of the skeleton"
+else
+    fail "the plan names every file of the skeleton" "not planned:$missing
+$plan"
+fi
+
+# --- the first run ---------------------------------------------------------
+
+assert_ok "the first run succeeds" "$REPO/bootstrap-private"
+
+# The fragment belongs at the root: under rcm/ it would be installed as
+# ~/.rcrc, over the file that sources it, and the tasks refuse to run at all.
+if [ -f "$dest/rcrc" ] && [ ! -e "$dest/rcm/rcrc" ]; then
+    pass "the rcrc fragment lands at the root, not under rcm/"
+else
+    fail "the rcrc fragment lands at the root, not under rcm/" \
+        "$(find "$dest" -name rcrc 2>&1)"
+fi
+
+# rcm only runs a hook it can execute.
+if [ -x "$dest/rcm/hooks/post-up" ]; then
+    pass "the hook is executable"
+else
+    fail "the hook is executable" "$(ls -l "$dest/rcm/hooks/post-up" 2>&1)"
+fi
+
+assert_equal "the first commit is named Initial commit" \
+    "Initial commit" "$(git -C "$dest" log -1 --format=%s 2>&1)"
+
+assert_equal "it commits on main" \
+    "main" "$(git -C "$dest" rev-parse --abbrev-ref HEAD 2>&1)"
+
+assert_equal "the repository is created with a description" \
+    "Private sidecar for krlmlr/scriptlets -- the dotfiles that must not be public" \
+    "$(cat "$work/state/description" 2>&1)"
+
+# --- a second run converges ------------------------------------------------
+
+# What a sidecar is for, added the way its owner would add it.
+printf 'export A_REAL_SECRET=hunter2\n' >>"$dest/rcm/bash_secrets"
+git -C "$dest" add -A
+git -C "$dest" commit -q -m "a secret"
+
+secret_before=$(cat "$dest/rcm/bash_secrets")
+head_before=$(git -C "$dest" rev-parse HEAD)
+
+assert_ok "a second run succeeds" "$REPO/bootstrap-private"
+again=$("$REPO/bootstrap-private" 2>&1)
+
+if printf '%s\n' "$again" | grep -q '^  + '; then
+    fail "a settled run creates nothing" \
+        "$(printf '%s\n' "$again" | grep '^  + ')"
+else
+    pass "a settled run creates nothing"
+fi
+
+assert_equal "a file edited by hand is left alone" \
+    "$secret_before" "$(cat "$dest/rcm/bash_secrets")"
+
+assert_equal "no second commit is invented" \
+    "$head_before" "$(git -C "$dest" rev-parse HEAD 2>&1)"
+
+assert_equal "the skeleton is committed once, not again" \
+    "2" "$(git -C "$dest" rev-list --count HEAD 2>&1)"
+
+# --- the description follows -d --------------------------------------------
+
+"$REPO/bootstrap-private" -d "Another description" >/dev/null 2>&1
+
+assert_equal "-d updates the description on a repository that exists" \
+    "Another description" "$(cat "$work/state/description" 2>&1)"
+
+repeat=$("$REPO/bootstrap-private" -d "Another description" 2>&1)
+
+if printf '%s\n' "$repeat" | grep -q '^  ~ '; then
+    fail "the same -d twice is not an update" \
+        "$(printf '%s\n' "$repeat" | grep '^  ~ ')"
+else
+    pass "the same -d twice is not an update"
+fi
+
+rm -rf "$work"


### PR DESCRIPTION
Follow-up to #47, on top of it rather than beside it.

## A description

`gh repo create` now carries `--description`, and `-d` overrides the default.

Setting it is a step of its own rather than an argument to creation, because
that is what makes it hold on a repository the script did not create:
a run with a different `-d` changes the description on GitHub,
and a run without one leaves it alone.

## Idempotent bootstrapping

`bootstrap-private` refused to run against a destination that already existed,
or a repository already on GitHub. A first attempt interrupted anywhere left
nothing to do but delete it and start again.

Every step now inspects, acts only where the state differs, and reports which
of the three it found:

```
  =  rcm/bash_secrets
  +  rcm/hooks/post-up
  ~  description: Private sidecar for krlmlr/scriptlets
```

A run reads as what changed rather than as what ran, and a settled one is all
`=`. Reruns converge — after an interruption, on a machine where half of it is
already done, or once the script has grown another step.

**The rule that makes this safe: a file that exists is never rewritten.**
By the second run it may hold the secrets the sidecar exists to hold, and
nothing here can tell the skeleton it wrote from what was put there afterwards.

`origin` is the other thing a rerun will not adjust. A remote pointing
somewhere else is a decision, and pushing to it would be this script guessing
which — so it stops and says so instead.

## The contract for the next step

The file header states it, since the bootstrapping is going to grow:
inspect first, act only where the state differs, report exactly once through
`same`/`made`/`changed`, and return early on `-n` after reporting.
Then name the function in the run of steps at the bottom.

## Testing

`tests/checks/27-bootstrap-private.sh` runs the bootstrap twice, because
that is the only way to see idempotency: the second run must create nothing,
invent no commit, and leave a file edited by hand exactly as it was.
It also pins the shape the first run produces — the fragment at the root
rather than under `rcm/`, where it would install as `~/.rcrc` over the file
that sources it; the hook executable, which is the only kind rcm runs;
`Initial commit` on `main`.

GitHub is a stub answering the handful of `gh` calls the script makes.
Being a stub, it pins the calls as much as the behaviour: a step that reaches
for `gh` in a new way fails there rather than going untested, which is the
point at which to decide whether the stub or the step is wrong.

Two mutations confirm the check bites — seeding that rewrites unconditionally,
and committing on every run. Both are caught, including the one that would
clobber a secret.

The suite passes against the branch and against a `git archive` export of the
commit, which is the check that would have caught the missing-file failure in
#47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu)_