### PR TITLE
fix: address `gh repo edit` by owner and name, and default to the description in use

### DIFF
--- a/bootstrap-private
+++ b/bootstrap-private
@@ -21,8 +21,14 @@
 set -eu
 
 repo_name=scriptlets-private
-repo_desc="Private sidecar for krlmlr/scriptlets -- the dotfiles that must not be public"
+repo_desc="Private counterpart of https://github.com/krlmlr/scriptlets"
 dry_run=0
+
+# The repository as OWNER/REPO, worked out once it is known to exist.
+# `gh repo view` and `gh repo create` take the bare name and resolve it against
+# the account; `gh repo edit` refuses it and wants the owner spelled out. Every
+# call after ensure_github uses this rather than $repo_name for that reason.
+repo_slug=
 
 REPO=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 
@@ -294,12 +300,14 @@ ensure_github() {
     fi
 
     if gh repo view "$repo_name" >/dev/null 2>&1; then
-        same "GitHub repository $(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner)"
+        repo_slug=$(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner)
+        same "GitHub repository $repo_slug"
         return 0
     fi
 
     gh repo create "$repo_name" --private --description "$repo_desc" >/dev/null
-    made "GitHub repository $(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner), private"
+    repo_slug=$(gh repo view "$repo_name" --json nameWithOwner -q .nameWithOwner)
+    made "GitHub repository $repo_slug, private"
 }
 
 # Separate from creating it, because the description is the one property this
@@ -322,14 +330,14 @@ ensure_description() {
         return 0
     fi
 
-    current=$(gh repo view "$repo_name" --json description -q .description)
+    current=$(gh repo view "$repo_slug" --json description -q .description)
 
     if [ "$current" = "$repo_desc" ]; then
         same "description"
         return 0
     fi
 
-    gh repo edit "$repo_name" --description "$repo_desc" >/dev/null
+    gh repo edit "$repo_slug" --description "$repo_desc" >/dev/null
     changed "description: $repo_desc"
 }
 
@@ -345,7 +353,7 @@ ensure_remote() {
         return 0
     fi
 
-    url=$(gh repo view "$repo_name" --json sshUrl -q .sshUrl)
+    url=$(gh repo view "$repo_slug" --json sshUrl -q .sshUrl)
 
     if existing=$(git -C "$dest" remote get-url origin 2>/dev/null); then
         # Not rewritten: a remote pointing somewhere else is a decision, and
@@ -408,7 +416,7 @@ if [ "$dry_run" -eq 1 ]; then
 fi
 
 echo
-echo "# $(gh repo view "$repo_name" --json url -q .url)"
+echo "# $(gh repo view "$repo_slug" --json url -q .url)"
 
 # What the sidecar adds, resolved the way an install resolves it.
 if command -v lsrc >/dev/null; then

--- a/tests/checks/27-bootstrap-private.sh
+++ b/tests/checks/27-bootstrap-private.sh
@@ -40,12 +40,13 @@ flag() {
 case "${1:-} ${2:-}" in
 "auth status") exit 0 ;;
 "repo view")
+    # Takes a bare name and resolves it against the account, as gh does.
     [ -f "$GH_STATE/exists" ] || exit 1
     case "$(flag -q "$@")" in
-    .nameWithOwner) echo "stub/$3" ;;
+    .nameWithOwner) echo "stub/${3##*/}" ;;
     .description) cat "$GH_STATE/description" 2>/dev/null || true; echo ;;
     .sshUrl) echo "$GH_STATE/remote.git" ;;
-    .url) echo "https://github.example/stub/$3" ;;
+    .url) echo "https://github.example/stub/${3##*/}" ;;
     esac
     exit 0
     ;;
@@ -57,6 +58,16 @@ case "${1:-} ${2:-}" in
     exit 0
     ;;
 "repo edit")
+    # gh insists on OWNER/REPO here where `repo view` is happy with a bare
+    # name, and says so in exactly these words. Refusing it here too is the
+    # whole value of the stub: the asymmetry is real, and easy to write past.
+    case "${3:-}" in
+    */*) ;;
+    *)
+        echo "expected the \"[HOST/]OWNER/REPO\" format, got \"${3:-}\"" >&2
+        exit 1
+        ;;
+    esac
     printf '%s' "$(flag --description "$@")" >"$GH_STATE/description"
     exit 0
     ;;
@@ -134,7 +145,7 @@ assert_equal "it commits on main" \
     "main" "$(git -C "$dest" rev-parse --abbrev-ref HEAD 2>&1)"
 
 assert_equal "the repository is created with a description" \
-    "Private sidecar for krlmlr/scriptlets -- the dotfiles that must not be public" \
+    "Private counterpart of https://github.com/krlmlr/scriptlets" \
     "$(cat "$work/state/description" 2>&1)"
 
 # --- a second run converges ------------------------------------------------


### PR DESCRIPTION
From running `bootstrap-private` against real GitHub, where the description of
an already-existing repository could not be updated:

```
  =  GitHub repository krlmlr/scriptlets-private
expected the "[HOST/]OWNER/REPO" format, got "scriptlets-private"
```

## The asymmetry

`gh repo view` and `gh repo create` take a bare repository name and resolve it
against the account. `gh repo edit` refuses one and wants `OWNER/REPO`.

Nothing about the calls looks different, so passing `$repo_name` to all three
reads as consistent right up until the one that says no. The name is now
resolved to `OWNER/REPO` once, as soon as the repository is known to exist, and
every `gh` call after that uses it.

Because the failure came at the description step, the two steps after it — the
remote and the push — did not run. Re-running is enough to finish the job,
which is what idempotency bought.

## The stub was the reason CI missed it

`27-bootstrap-private.sh` already covers this exact path: it edits the
description of a repository that exists. It passed anyway, because the stub
standing in for `gh` accepted a bare name everywhere — it was more permissive
than the thing it imitates, and a stub is only worth as much as the places it
says no.

The stub now refuses a bare name for `repo edit`, in gh's own words. Against
the unfixed script that reproduces the failure exactly, so the check would have
caught this before it reached a real machine.

`repo view` still takes either form, since gh does — the point is to mirror the
asymmetry, not to tighten everything indiscriminately.

## Also

The default description becomes `Private counterpart of
https://github.com/krlmlr/scriptlets`, the one being given in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu)_