### PR TITLE
fix(`h`): keep the interactive scratch file in scope

### DIFF
--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -146,6 +146,10 @@ and they run in name order:
   a run that ends on the first repository prints nothing at all,
   which is also what an empty directory looks like,
   so the check names the repositories it expects to hear back from.
+  The repository it is *standing in* is not among them,
+  which is the other half of "below";
+  `-n` emits the commands instead of running them;
+  and `s` reaches the same repositories with `git` in front.
   It links the `fd`, `gsed` and `gsort` names Linux does not ship
   ([`install/prerequisites/`](/handbook/install/prerequisites/README.md))
   and skips where the commands behind them are missing too.

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -42,6 +42,15 @@ The switches:
   The [`NO_COLOR`](https://no-color.org/) environment variable also
   disables color unless `--color=always` is given.
 
+The exit status is the parallel run's, not the repositories'.
+Every generated command ends in the `sed` that names its output,
+so a repository whose command failed says so in the output
+and leaves `$?` at zero.
+`-i` is the mode that stops at the first failure
+and passes that status on,
+so a script that needs to know reaches for it
+rather than for the parallel default.
+
 [`gita`](https://github.com/nosarthur/gita) both does too much and not
 enough; these stay home-grown.
 Not yet integrated with `inside` and `every`, which cover the

--- a/rcm/bin/h
+++ b/rcm/bin/h
@@ -198,7 +198,9 @@ process_cmd() {
       cat
     fi
   elif $interactive; then
-    local cmds
+    # Not `local`: the EXIT trap runs after this function has returned, so a
+    # local would be out of scope by then -- `set -u` would abort on it and the
+    # file would outlive the run it belongs to.
     cmds=$(mktemp -u "${TMPDIR:-/tmp}/h-cmds-XXXXXX")
     trap 'rm -f "$cmds"' EXIT
 

--- a/tests/checks/75-h.sh
+++ b/tests/checks/75-h.sh
@@ -58,6 +58,9 @@ fi
 PATH="$work/shims:$PATH"
 export PATH
 
+# A repository holding the two, so "below the current directory" has the case
+# that says *below*: the one the command runs in is not one of them.
+git init -q "$work"
 git init -q "$work/one"
 git init -q "$work/two"
 
@@ -76,3 +79,20 @@ for repo in one two; do
         ;;
     esac
 done
+
+assert_equal "the repository h runs in is not one it runs the command in" \
+    "one two" "$(printf '%s\n' "$output" | sed 's/:.*//' | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+# `-n` is the half that needs no parallel: it emits the commands, and that is
+# all it does.
+dry=$(cd "$work" && h -n touch dry-run-marker 2>&1)
+assert_equal "--dry-run emits a command per repository" \
+    "2" "$(printf '%s\n' "$dry" | grep -c '^bash -c ')"
+assert_equal "--dry-run does not run them" \
+    "" "$(find "$work" -name dry-run-marker)"
+
+# `s` is `h git`, and its own argument parsing sits in front of that.
+# `rev-parse --git-dir` answers in a repository that has no commit yet.
+answered=$(cd "$work" && s --no-color rev-parse --git-dir 2>&1 |
+    sed 's/:.*//' | sort -u | tr '\n' ' ' | sed 's/ $//')
+assert_equal "s prepends git and reaches every repository" "one two" "$answered"


### PR DESCRIPTION
`((++i))` (#48) got `h` running again.
A second abort sat behind it, in the interactive path.

## The fix

`cmds` was declared `local` in the function that sets the EXIT trap,
so by the time the trap fired the name was out of scope,
`set -u` aborted on it,
and the file it was meant to remove stayed behind.
`hi` and `si` ended every run that way.

## The cases `75-h` grows

That a repository is found *below* the current directory is half a claim.
The other half is that the one the command runs in is **not** among them,
so the tree the check builds is now itself a repository —
the case a plain directory cannot show.

`-n` emits the commands rather than running them,
which is the half of `h` that needs no GNU parallel.

And `s` is covered at all,
having been as broken as `h` was, and as untested.

Reintroducing `((i++))` on top of this fails six of the seven assertions,
so the check holds the ground #48 took.
This is also the first run where any of `75-h` reaches CI,
since #48 is what taught the workflow to install the tools `h` drives.

## `handbook/tools/`

Noticed while reading the parallel path, and undocumented until now:
the exit status is the run's, not the repositories'.
Every generated command ends in the `sed` that names its output,
so a repository whose command failed says so in the output
and leaves `$?` at zero.
`-i` is the mode that stops at the first failure and passes that status on,
which is what a script wanting to know should reach for.

---

Found while investigating whether
[`krlmlr/repo-sync`](https://github.com/krlmlr/repo-sync)'s mirror
synchronization should be driven by `s` —
which required `s` to run at all.

https://claude.ai/code/session_01L8wcjryCJaaeEQ47Hpxvdv
