### PR TITLE
docs(`h`): say that a bare repository is not one it finds

### DIFF
--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -24,6 +24,11 @@ the script's help owns the detail and the entry stays a summary.
 **`h`** finds every Git repository below the current directory
 and executes a command in each of them.
 Linked worktrees are included, since they carry a `.git` file.
+Bare repositories are not:
+they have no `.git` entry to be found by —
+HEAD, config, objects and refs sit at the top of the directory instead —
+so a bare clone stays out of the sweep,
+and needs something other than a sweep to keep it up to date.
 **`s`** prepends `git` — it is a wrapper around `h git`.
 The switches:
 

--- a/tests/checks/75-h.sh
+++ b/tests/checks/75-h.sh
@@ -96,3 +96,14 @@ assert_equal "--dry-run does not run them" \
 answered=$(cd "$work" && s --no-color rev-parse --git-dir 2>&1 |
     sed 's/:.*//' | sort -u | tr '\n' ' ' | sed 's/ $//')
 assert_equal "s prepends git and reaches every repository" "one two" "$answered"
+
+# A bare repository is not one of them. The search is for a `.git` entry, and
+# a bare repository has none: its HEAD, config, objects and refs sit at the top
+# of the directory instead. That is what lets a bare clone sit beside a tree of
+# checkouts and stay out of every sweep over it -- and what makes a sweep the
+# wrong tool for keeping one up to date.
+git init -q --bare "$work/three.git"
+
+assert_equal "a bare repository is not one h finds" "one two" \
+    "$(cd "$work" && h --no-color echo scriptlets 2>&1 |
+        sed 's/:.*//' | sort -u | tr '\n' ' ' | sed 's/ $//')"


### PR DESCRIPTION
## Why

`h` finds repositories by their `.git` entry, which is why
[`handbook/tools/`](https://github.com/krlmlr/scriptlets/blob/main/handbook/tools/README.md)
says linked worktrees are included: they carry one, as a file. The other half of
that sentence was missing. A bare repository has no `.git` entry at all — its
`HEAD`, `config`, `objects` and `refs` sit at the top of the directory — so it
is not in the sweep, and anything that needs a bare clone kept current needs
something other than `h`/`s` to do it.

This came up in `krlmlr/repo-sync#7`, where the mirror tree grows a bare clone
of the template beside the checkouts, and the question was whether `s` would
reach it. It does not, by construction — worth writing down where the claim
about worktrees already lives.

## What changed

- `handbook/tools/README.md`: the paragraph on `h` now names bare repositories
  alongside linked worktrees, and says what follows from it.
- `tests/checks/75-h.sh`: a bare repository beside `one` and `two` leaves the
  answer at `one two`, so the page's claim is pinned rather than asserted.

## Verification

`tests/run` passes in full (the `75-h` check runs here rather than skipping —
`fd`, `parallel` and the GNU shims are all present), including the new
assertion.


---
_Generated by [Claude Code](https://claude.ai/code/session_011nbMUtK5yRxKp4m2JrVohT)_