### PR TITLE
feat: start a sidecar's history from an empty commit

### DIFF
--- a/bootstrap-private
+++ b/bootstrap-private
@@ -259,9 +259,46 @@ ensure_git() {
     git -C "$dest" symbolic-ref HEAD refs/heads/main
 }
 
+require_identity() {
+    git -C "$dest" var GIT_AUTHOR_IDENT >/dev/null 2>&1 ||
+        die "git has no identity here -- set user.name and user.email first"
+}
+
+# The history starts from an empty commit, so the skeleton arrives as a diff
+# like everything after it rather than as the state the repository began in.
+# What that buys is a root to stand on: `git rebase --onto` can reach every
+# real commit, the first one can be reverted or rewritten like any other, and
+# `git diff <root>` is the whole history of the tree.
+ensure_root_commit() {
+    if [ "$dry_run" -eq 1 ]; then
+        if [ -d "$dest/.git" ] &&
+            git -C "$dest" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+            same "root commit"
+        else
+            made 'empty root commit "Initial commit"'
+        fi
+        return 0
+    fi
+
+    if git -C "$dest" rev-parse --verify -q HEAD >/dev/null; then
+        same "root commit"
+        return 0
+    fi
+
+    require_identity
+    git -C "$dest" commit -q --allow-empty -m "Initial commit"
+    made 'empty root commit "Initial commit"'
+}
+
 ensure_commit() {
     if [ "$dry_run" -eq 1 ]; then
-        [ -d "$dest/.git" ] || made "commit \"Initial commit\""
+        if [ ! -d "$dest/.git" ]; then
+            made 'commit "Add the sidecar skeleton"'
+        elif [ -n "$(git -C "$dest" status --porcelain)" ]; then
+            made "commit of what is uncommitted here"
+        else
+            same "commit (nothing to commit)"
+        fi
         return 0
     fi
 
@@ -272,13 +309,14 @@ ensure_commit() {
         return 0
     fi
 
-    git -C "$dest" var GIT_AUTHOR_IDENT >/dev/null 2>&1 ||
-        die "git has no identity here -- set user.name and user.email first"
+    require_identity
 
-    if git -C "$dest" rev-parse --verify -q HEAD >/dev/null; then
-        message="Update the sidecar skeleton"
+    # One commit means the empty root and nothing else, so this is the skeleton
+    # arriving; anything later is a change to it.
+    if [ "$(git -C "$dest" rev-list --count HEAD)" -eq 1 ]; then
+        message="Add the sidecar skeleton"
     else
-        message="Initial commit"
+        message="Update the sidecar skeleton"
     fi
 
     git -C "$dest" commit -q -m "$message"
@@ -405,6 +443,7 @@ echo
 ensure_dir
 ensure_files
 ensure_git
+ensure_root_commit
 ensure_commit
 ensure_github
 ensure_description

--- a/handbook/layout/private/README.md
+++ b/handbook/layout/private/README.md
@@ -53,6 +53,15 @@ and the skeleton written into it; `-n` lists the files.
 The skeleton is empty of secrets and installs cleanly as it stands:
 every file in it is comments, saying what belongs there.
 
+**The history starts from an empty commit.**
+A new sidecar has two: `Initial commit`, holding nothing,
+and `Add the sidecar skeleton` on top of it.
+The skeleton then arrives as a diff like every change after it,
+rather than as the state the repository began in —
+which gives `git rebase --onto` a root to stand on,
+lets the first real commit be reverted or rewritten like any other,
+and makes `git diff <root>` the whole history of the tree.
+
 **Every step is idempotent, and says which of two things it found.**
 A step brings one thing to the state it should be in and reports it as
 created, already so, or updated,
@@ -73,6 +82,35 @@ which is also why a half-finished first attempt can simply be rerun.
 a remote pointing somewhere else is a decision,
 and pushing to it would be the script guessing which.
 It stops and says so instead.
+
+## Giving an older sidecar the empty root
+
+A sidecar created before the empty root existed
+begins at the commit that carries the skeleton,
+and rerunning the script will not change that:
+the history is already there,
+and rewriting one is not something a step does behind your back.
+Three commands do it, from the clone:
+
+```sh
+old_root=$(git rev-list --max-parents=0 HEAD)
+empty=$(git commit-tree -m "Initial commit" "$(git hash-object -w -t tree /dev/null)")
+skeleton=$(git commit-tree -p "$empty" -m "Add the sidecar skeleton" "$old_root^{tree}")
+git rebase --onto "$skeleton" "$old_root"
+```
+
+The first builds a commit with no parent and an empty tree.
+The second rebuilds the old root's tree on top of it
+under the name the script now gives that commit.
+The third replays whatever came after —
+nothing, on a sidecar that has only ever been created,
+and every commit of your own on one that has been used.
+
+Every commit gets a new hash, so the branch has to be published with
+`git push --force-with-lease`,
+and any other clone of it re-cloned rather than pulled.
+The working tree is untouched throughout:
+the files, and the secrets in them, come out byte for byte the same.
 
 ## What goes in it
 

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -83,8 +83,9 @@ and they run in name order:
 - `27-bootstrap-private`: `bootstrap-private` creates a sidecar
   and converges on a re-run:
   a dry run changes nothing and names every file it would write,
-  the first run commits the skeleton on `main` as `Initial commit`
-  with the fragment at the root and the hook executable,
+  the first run leaves two commits on `main` —
+  an empty `Initial commit` and the skeleton on top of it —
+  with the fragment at the repository root and the hook executable,
   and a settled run creates nothing,
   invents no commit,
   and leaves a file edited by hand exactly as it was.

--- a/tests/checks/27-bootstrap-private.sh
+++ b/tests/checks/27-bootstrap-private.sh
@@ -138,8 +138,24 @@ else
     fail "the hook is executable" "$(ls -l "$dest/rcm/hooks/post-up" 2>&1)"
 fi
 
-assert_equal "the first commit is named Initial commit" \
-    "Initial commit" "$(git -C "$dest" log -1 --format=%s 2>&1)"
+assert_equal "a fresh sidecar has two commits" \
+    "2" "$(git -C "$dest" rev-list --count HEAD 2>&1)"
+
+root=$(git -C "$dest" rev-list --max-parents=0 HEAD 2>/dev/null)
+
+assert_equal "the root commit is named Initial commit" \
+    "Initial commit" "$(git -C "$dest" show -s --format=%s "$root" 2>&1)"
+
+# The point of the root: the skeleton arrives as a diff like everything after
+# it, rather than as the state the repository began in.
+if [ -z "$(git -C "$dest" ls-tree "$root" 2>&1)" ]; then
+    pass "the root commit is empty"
+else
+    fail "the root commit is empty" "$(git -C "$dest" ls-tree "$root" 2>&1)"
+fi
+
+assert_equal "the skeleton is a commit of its own on top of it" \
+    "Add the sidecar skeleton" "$(git -C "$dest" log -1 --format=%s 2>&1)"
 
 assert_equal "it commits on main" \
     "main" "$(git -C "$dest" rev-parse --abbrev-ref HEAD 2>&1)"
@@ -175,7 +191,7 @@ assert_equal "no second commit is invented" \
     "$head_before" "$(git -C "$dest" rev-parse HEAD 2>&1)"
 
 assert_equal "the skeleton is committed once, not again" \
-    "2" "$(git -C "$dest" rev-list --count HEAD 2>&1)"
+    "3" "$(git -C "$dest" rev-list --count HEAD 2>&1)"
 
 # --- the description follows -d --------------------------------------------
 


### PR DESCRIPTION
A new sidecar has two commits now:

```
Add the sidecar skeleton
Initial commit          <- empty
```

The skeleton arrives as a diff like every change after it, rather than as the
state the repository began in. That gives `git rebase --onto` a root to stand
on, lets the first real commit be reverted or rewritten like any other, and
makes `git diff <root>` the whole history of the tree.

Creating the root is a step of its own, idempotent like the rest: a repository
that has any history at all keeps it.

## Giving an existing sidecar the empty root

A sidecar created before this still begins at the commit carrying the skeleton,
and rerunning the script will not change that — rewriting a history is not
something a step should do behind your back. The handbook carries the recipe;
from the clone:

```sh
old_root=$(git rev-list --max-parents=0 HEAD)
empty=$(git commit-tree -m "Initial commit" "$(git hash-object -w -t tree /dev/null)")
skeleton=$(git commit-tree -p "$empty" -m "Add the sidecar skeleton" "$old_root^{tree}")
git rebase --onto "$skeleton" "$old_root"

git push --force-with-lease
```

`commit-tree` builds a commit with no parent and an empty tree; the second
rebuilds the old root's tree on top of it under the name the script now gives
that commit; `rebase --onto` replays whatever came after — nothing on a sidecar
only ever created, and every commit of your own on one that has been used.

Both shapes were tried before this was written. The working tree comes out byte
for byte identical either way, secrets included; only the hashes change, which
is why the branch needs `--force-with-lease` and any other clone of it needs
re-cloning rather than pulling.

## Testing

`27-bootstrap-private.sh` now pins the shape: a fresh sidecar has exactly two
commits, the root is named `Initial commit`, `git ls-tree` on it is empty, and
the skeleton is a commit of its own on top. The idempotency assertions carry
over unchanged — a settled run still creates nothing and invents no commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WC9vzyXsNMEoNqC5G7Bkgu)_