### PR TITLE
feat(git): a `wt` family for worktrees, `sq` becomes `qs`, `sr` retires

### DIFF
--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -139,7 +139,7 @@ and they run in name order:
 - `70-git-ssh-remote`: `git ssh-remote` converts the HTTPS GitHub
   remotes of a throw-away repository
   and leaves every other remote alone,
-  through `~/bin` and through the `git sr` alias alike.
+  through the `~/bin` the installation puts on the `PATH`.
 - `75-h`: `h` runs the command in every repository below the current
   directory, and each line of output says which one it came from.
   Both halves matter:

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -97,7 +97,6 @@ turning `https://github.com/krlmlr/scriptlets.git`
 into `git@github.com:krlmlr/scriptlets.git`.
 This is the repair for a clone made with the URL GitHub offers first,
 which asks for a password on every push.
-The `git sr` alias is the short spelling.
 Named remotes are converted, all of them when none is named,
 fetch and push URLs alike;
 remotes that already speak SSH, and HTTPS remotes on other hosts,

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -133,3 +133,9 @@
 	stp = stash pop
 	std = stash drop
 	stl = stash list
+	# ---
+	# Worktree: git spells the concept as two words itself,
+	# in --work-tree and GIT_WORK_TREE, and they give the two letters.
+	# w is switch, and git matches an alias name in full, never by
+	# prefix, so the two never meet.
+	wt = worktree

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -122,8 +122,10 @@
 	qh = reset HEAD
 	sp = status --porcelain
 	# https://stackoverflow.com/a/5201642/946850
-	sq = !sh -c 'git reset --soft ${1:-main} && git commit --edit -m$(git log --format=%B --reverse HEAD..HEAD@{1})'
-	sr = ssh-remote
+	# The squash belongs to the reset family: the letters are qs, and the
+	# old spelling warns, then forwards.
+	qs = "!sh -c 'git reset --soft ${1:-main} && git commit --edit -m \"$(git log --format=%B --reverse HEAD..HEAD@{1})\"' -"
+	sq = "!echo 'warning: sq is now qs' >&2; git qs"
 	# hub
 	pr = !sh -c 'hub pull-request "$@"'
 	prm = !sh -c 'hub pull-request -b main "$@"'
@@ -139,3 +141,15 @@
 	# w is switch, and git matches an alias name in full, never by
 	# prefix, so the two never meet.
 	wt = worktree
+	wta = worktree add
+	wtl = worktree list
+	wtm = worktree move
+	wtp = worktree prune
+	wtr = worktree remove
+	# wtb <branch> puts a worktree beside the repository it belongs to,
+	# named for both: ~/git/repo and branch-name make
+	# ~/git/repo-branch-name, and a slash in the branch name folds to a
+	# dash, so the sibling stays one directory rather than a nest.
+	# A branch that exists, here or on a remote, is checked out;
+	# a name that is neither becomes a new branch.
+	wtb = "!f() { r=$(git worktree list --porcelain | sed -n '1s/^worktree //p'); d=$r-$(printf %s $1 | tr / -); if git show-ref --verify --quiet refs/heads/$1 || test -n \"$(git for-each-ref --count=1 'refs/remotes/*/'$1)\"; then git worktree add \"$d\" $1; else git worktree add -b $1 \"$d\"; fi; }; f"

--- a/tests/checks/70-git-ssh-remote.sh
+++ b/tests/checks/70-git-ssh-remote.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # `git ssh-remote` converts what it promises to convert and nothing else. The
-# script is exercised through the installed ~/bin and through the `git sr`
-# alias from the installed ~/.gitaliases, so the check covers the wiring as
-# well as the conversion.
+# script is exercised through the installed ~/bin, as `git ssh-remote`, so the
+# check covers the wiring as well as the conversion.
 #
 # The repository it works on is a throw-away one below $HOME: `git init`
 # contacts nothing, and neither does rewriting a URL.
@@ -45,10 +44,9 @@ assert_equal "a remote that already speaks SSH is left alone" \
 assert_equal "a remote on another host is left alone" \
     "https://gitlab.com/krlmlr/elsewhere.git" "$(url_of elsewhere)"
 
-# --all-hosts is what that other host waits for, and the alias is the spelling
-# that has to work as well as the name does.
-assert_ok "git sr --all-hosts succeeds" \
-    git -C "$work" sr --all-hosts elsewhere
+# --all-hosts is what that other host waits for.
+assert_ok "git ssh-remote --all-hosts succeeds" \
+    git -C "$work" ssh-remote --all-hosts elsewhere
 assert_equal "--all-hosts converts a remote on another host" \
     "git@gitlab.com:krlmlr/elsewhere.git" "$(url_of elsewhere)"
 


### PR DESCRIPTION
Three changes to `rcm/gitaliases`, with the reasoning kept in the file as comments,
since the alias file owns what it lists.

## `wt`, and a family under it

`wt = worktree` takes git's own abbreviation:
git spells the concept as two words wherever it names it —
`--work-tree`, `GIT_WORK_TREE`, "work tree" throughout the prose —
so `w` and `t` are the initials of the thing rather than a squeeze of one word.

`w = switch` already holds the letter, but the collision is a reading problem, not a dispatch one:
git matches alias names in full, never by prefix,
and nothing here sets `help.autocorrect`,
the one mechanism that could turn a near-miss into the other command.
The file already stacks unrelated names on occupied prefixes —
`conflicts` under `co = checkout`, `echo` under `e = restore`.

The letter is safe to spend because `switch -t` has almost nothing left to do:
`--guess` is on by default and `rcm/gitconfig` sets `checkout.defaultRemote = origin`,
so `git w feature` already builds the tracking branch from the remote.

Then the four subcommands worth shortening:

* `wta` add, `wtl` list, `wtm` move, `wtp` prune, `wtr` remove
* lock, unlock and repair stay spelled out — a verb reached for once a year reads better in full

`wtb <branch>` is the composite:
it puts a worktree beside the repository it belongs to and names it for both,
so `~/git/repo` and `branch-name` make `~/git/repo-branch-name`.
The name comes from the main worktree, not the current one,
so a `wtb` run from inside a linked worktree is a sibling rather than a nest,
and a slash in the branch name folds to a dash for the same reason.
A branch that already exists, here or on exactly one remote, is checked out —
git's own DWIM sets the tracking branch up —
and a name that is neither becomes a new branch.
All four paths exercised against git 2.54.

Completion follows every one of these:
git's completion expands a non-shell alias to its first command word,
so `git wt <TAB>` offers the `worktree` subcommands.

## `sq` becomes `qs`

The squash is a `reset --soft` that ends in a commit,
so it belongs to the reset family rather than under `status`.
The old spelling warns and forwards, the way `phuc` and `phuo` already do.

Two bugs came along and are fixed:

* the `sh -c` had no `-` placeholder, so `${1:-main}` never saw the argument —
  `git sq HEAD~3` squashed back to `main` regardless
* the unquoted `-m$(...)` split the collected message on whitespace,
  so every commit whose subject had a space failed as a pathspec

## `sr` retires

`git ssh-remote` is the name the script already answers to through `~/bin`,
and the two-letter spelling bought nothing that completion does not.
Both handbook mentions and the `70-git-ssh-remote` check move to the full name;
the full suite passes.

## Not changed

No handbook page for the aliases themselves:
the alias file is the inventory,
and [`meta/authoring/`](https://github.com/krlmlr/scriptlets/blob/main/handbook/meta/authoring/README.md)
rules out re-enumerating what a file lists.