### PR TITLE
feat(macos): link Positron's command line tool into `~/bin` as `positron`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ and what none of them carries.
   linked into place by rcm under
   [per-user and per-platform tags](handbook/layout/README.md),
   with `~/bin` put on the `PATH` on macOS too.
+* On macOS, installing also links
+  [Positron's command line tool](handbook/install/hooks/README.md)
+  into `~/bin` as `positron` —
+  the file inside the bundle is called `code`,
+  which is VS Code's.
 * [`mise run import`](handbook/install/import/README.md)
   moves a dotfile you already have into the repository
   and links it back where it was.

--- a/handbook/install/README.md
+++ b/handbook/install/README.md
@@ -6,5 +6,6 @@ is [`layout/`](/handbook/layout/README.md)'s.
 
 * [`tasks/`](tasks/) — the task set: mise and `make`, trust, uninstall
 * [`bootstrap/`](bootstrap/) — one-shot setup from nothing
+* [`hooks/`](hooks/) — what runs around rcm's linking, and the Positron link
 * [`import/`](import/) — moving a file you already have into the repository
 * [`prerequisites/`](prerequisites/) — rcm, mise, what single scripts need

--- a/handbook/install/hooks/README.md
+++ b/handbook/install/hooks/README.md
@@ -1,0 +1,121 @@
+# `install/hooks/`
+
+What runs around rcm's linking and unlinking,
+and what this repository does with it.
+Which files rcm links, and where they land,
+is [`layout/mapping/`](/handbook/layout/mapping/README.md)'s.
+
+## The mechanism
+
+The hooks are rcm's, and its man pages own them.
+`rcup` runs `hooks/pre-up` before it links and `hooks/post-up` after;
+`rcdn` runs `hooks/pre-down` and `hooks/post-down` around unlinking.
+Each name may be a single file or a directory of them,
+and a directory's files run in name order,
+so [`rcm/hooks/post-up/`](/rcm/hooks/post-up) holds one file per concern
+the way [`mise-tasks/`](/mise-tasks) holds one file per task.
+
+Three properties of the mechanism are load-bearing here:
+
+* **Only executable files run**,
+  and a file without the bit is passed over in silence —
+  which is why
+  [`tests/checks/78-positron.sh`](/tests/checks/78-positron.sh)
+  checks the bit rather than trusting it,
+  and why the shared
+  [`rcm/hooks/positron.sh`](/rcm/hooks/positron.sh)
+  is not executable:
+  it is sourced by the hooks, never run as one.
+* **`hooks/` is never installed.**
+  rcm skips the directory by name, in every tree it walks,
+  so nothing under it needs an `UNDOTTED` entry
+  and nothing lands in the home directory as `~/.hooks`.
+* **Each hook runs from the directory it sits in**,
+  so a hook reaches its neighbours as `./name`
+  and the tree above it as `../name`,
+  wherever the clone lives.
+
+Hooks are per tree:
+a private sidecar runs its own, from its own `hooks/`
+([`layout/private/`](/handbook/layout/private/README.md)).
+`mise run check` runs none of them —
+`lsrc` only lists the mapping —
+and `rcup -K` skips them for one run.
+
+**Which trees' hooks run is not settled by `-d` alone.**
+Both commands look for hooks below `DOTFILES_DIRS`,
+and only `rcup` assigns that from the `-d` it was given:
+`rcdn` keeps `-d` to itself
+(checked against rcm 1.3.4).
+An uninstall run from a clone anywhere else
+would therefore unlink one tree and run another tree's hooks,
+or none at all.
+The tasks name the trees in the environment as well as in `-d`,
+and [`rcm/rcrc`](/rcm/rcrc) defers to a value already set,
+so the two readings cannot come apart
+([`install/tasks/`](/handbook/install/tasks/README.md)).
+
+## The Positron link
+
+`mise run install` on macOS links Positron's command line tool into
+`~/bin` under the name `positron`,
+and `mise run uninstall` takes the link away again.
+The pair is [`rcm/hooks/post-up/positron`](/rcm/hooks/post-up/positron)
+and [`rcm/hooks/pre-down/positron`](/rcm/hooks/pre-down/positron),
+over the paths and the tests in
+[`rcm/hooks/positron.sh`](/rcm/hooks/positron.sh).
+
+**The name is the whole reason there is a hook.**
+Positron is a VS Code fork,
+and the tool inside its bundle carries the name it inherited: `code`.
+It cannot be renamed where it sits —
+an application bundle is signed, and an update replaces it —
+so putting that directory on the `PATH`
+is putting a second `code` there,
+one that shadows VS Code's or is shadowed by it
+depending on which came first.
+A symbolic link under a name of our choosing is the way out,
+and reaching the tool through one is a case it handles:
+it follows the link back to the bundle it lives in
+before it looks for anything beside it.
+A link is not something the repository can ship as a file, though:
+its target is an absolute path outside the repository,
+present on some accounts and not others,
+which is a decision that has to be made on the machine —
+hence a hook rather than a file under `rcm/`.
+
+**Where it looks.**
+`$HOME/Applications/Positron.app` first, then `/Applications/Positron.app`,
+taking the per-user install over the system-wide one when both are there.
+`SCRIPTLETS_POSITRON_APP` names one bundle instead of both;
+the check drives the hooks with it,
+and an account with Positron somewhere else can set it too.
+An account with no bundle at either place gets no link and no message.
+
+**What it will not touch.**
+A `~/bin/positron` that is not a symbolic link into a `Positron.app`
+belongs to the account,
+and the hook keeps it and says so on standard error.
+rcm asks before replacing a file it did not create;
+a hook cannot ask,
+because an install must not stop at a prompt
+([`layout/mapping/`](/handbook/layout/mapping/README.md)
+says what rcm's own prompt does).
+The same test decides what `pre-down` removes:
+a link into a bundle goes, anything else stays.
+A link of ours whose bundle has been deleted is removed
+on the next install.
+
+## Limits
+
+**The link follows an install, not the application.**
+Installing Positron after the last `mise run install`
+leaves the link uncreated until the next one;
+nothing watches `/Applications`.
+Moving the bundle is the same,
+except that the stale link is dangling in the meantime.
+
+**Positron is the only application here.**
+Nothing generalises the pattern to other bundles that ship a CLI,
+and a second one would be a second hook file beside this one
+rather than a list this one reads.

--- a/handbook/install/tasks/README.md
+++ b/handbook/install/tasks/README.md
@@ -65,7 +65,9 @@ and points at mise for the three that need it.
 too long for a one-liner.
 Every task points `RCRC` at the repository's own copy of `rcrc`,
 and the ones that invoke rcm go through `lib.sh`'s `rcm_run`,
-which passes `-d`,
+which passes `-d` and sets `DOTFILES_DIRS` to the same trees —
+the second because that, not `-d`, is where rcm looks for the hooks it
+runs ([`install/hooks/`](/handbook/install/hooks/README.md)) —
 so the tasks work from any clone location
 and take effect even before — or instead of — an existing `~/.rcrc`
 (the mapping that file drives is

--- a/handbook/layout/mapping/README.md
+++ b/handbook/layout/mapping/README.md
@@ -1,6 +1,6 @@
 # The mapping
 
-Everything that ends up in the home directory lives in
+Everything rcm links into the home directory lives in
 [`rcm/`](/rcm).
 A name there gains a leading dot on the way to `$HOME`,
 so `rcm/bashrc` becomes `~/.bashrc`
@@ -16,15 +16,24 @@ rcm skips names that already start with a dot inside `rcm/`,
 which is why the placeholder that brings `~/log` into existence
 is [`rcm/log/dummy`](/rcm/log/dummy), kept dotless.
 
+`rcm/hooks/` is the one name rcm keeps for itself:
+it runs what is below it, on every tree it walks, and installs none of it.
+A hook is also the one thing here that can put something in the home
+directory without a file behind it —
+a symbolic link to a path outside the repository is a decision
+that has to be made on the machine
+([`install/hooks/`](/handbook/install/hooks/README.md)).
+
 **`rcrc` itself** sets `DOTFILES_DIRS`, `UNDOTTED` and `TAGS`
 (the tags are [`layout/tags/`](/handbook/layout/tags/README.md)'s),
 and is installed as `~/.rcrc`.
-It hardcodes `DOTFILES_DIRS="$HOME/git/scriptlets/rcm"`,
+`DOTFILES_DIRS` defaults there to `$HOME/git/scriptlets/rcm`,
 so a bare `rcup` or `lsrc` finds nothing
 unless the clone lives at `~/git/scriptlets`,
 where the bootstrap script puts it
 ([`install/bootstrap/`](/handbook/install/bootstrap/README.md));
-the tasks work from any location
+a value already in the environment wins instead,
+which is how the tasks work from any location
 ([`install/tasks/`](/handbook/install/tasks/README.md) says how).
 
 **What an install touches.**

--- a/handbook/layout/private/README.md
+++ b/handbook/layout/private/README.md
@@ -142,8 +142,9 @@ rather than let it happen quietly.
 **Tags and hooks are per tree.**
 `tag-<user>/`, `tag-<platform>/` and `host-<name>/` in the sidecar are
 selected by the same `TAGS` the public `rcrc` computes.
-`hooks/pre-up` and `hooks/post-up` are the sidecar's own:
-rcm runs them from the directory they sit in and never installs it.
+The sidecar's `hooks/` is its own,
+run in its turn alongside this repository's
+([`install/hooks/`](/handbook/install/hooks/README.md)).
 That is where the `chmod` goes that keeps `~/.ssh/config-private`
 unreadable to anyone else —
 rcm links rather than copies,

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -9,6 +9,7 @@ one line, so the register stays greppable and diffs per term.
 * **check** — one script in `tests/checks/`, run in name order against the throw-away home ([`testing/`](/handbook/testing/README.md)).
 * **fragment** — the `rcrc` at a sidecar's root, appending to the variables rcm applies to every tree ([`layout/private/`](/handbook/layout/private/README.md)).
 * **dump** — zsh's completion dump, audited once a day and trusted in between ([`config/completion/`](/handbook/config/completion/README.md)).
+* **hook** — a script rcm runs before or after it links or unlinks, from the tree it belongs to ([`install/hooks/`](/handbook/install/hooks/README.md)).
 * **import** — moving a file you already have into the repository, linked back where it was ([`install/import/`](/handbook/install/import/README.md)).
 * **sidecar** — a second, private dotfiles tree merged into the same home directory ([`layout/private/`](/handbook/layout/private/README.md)).
 * **stamp** — the `.audited` file that dates the last completion audit ([`config/completion/`](/handbook/config/completion/README.md)).

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -153,6 +153,20 @@ and they run in name order:
   It links the `fd`, `gsed` and `gsort` names Linux does not ship
   ([`install/prerequisites/`](/handbook/install/prerequisites/README.md))
   and skips where the commands behind them are missing too.
+- `78-positron`: the hooks that keep `~/bin/positron` pointing at
+  Positron's command line tool
+  ([`install/hooks/`](/handbook/install/hooks/README.md))
+  link it, leave it alone once it is right,
+  keep a file of the account's own that is in the way,
+  drop a link into a bundle that is gone,
+  and take the link away again on the way out.
+  It also drives one install and uninstall through the tasks,
+  for the half running the hooks by hand cannot show:
+  that rcm reaches them at all, from a clone anywhere.
+  It builds a bundle of its own and stubs `uname`,
+  because Positron is macOS-only and on neither CI runner,
+  and brings its own home directory,
+  the throw-away one being what the other checks read.
 - `90-force`: `mise run force` replaces the files rcm skipped,
   and the scripts are still found afterwards.
   It runs last because it is the one check

--- a/mise-tasks/lib.sh
+++ b/mise-tasks/lib.sh
@@ -41,13 +41,21 @@ fi
 # Every task that reaches rcm goes through here, so none of them can act on a
 # different set of trees than the others -- an install that saw the sidecar and
 # an uninstall that did not would strand every link the sidecar owns.
+#
+# The same list also goes into the environment, because rcm reads the trees
+# twice and only one of the readings honours -d: `rcup` assigns DOTFILES_DIRS
+# from it and `rcdn` keeps it to itself, while the hooks of both are looked for
+# below DOTFILES_DIRS (rcm 1.3.4). Without this an uninstall would unlink one
+# tree and run another tree's hooks -- handbook/install/hooks/README.md.
+# rcm/rcrc defers to a value already set, so the two never disagree.
 rcm_run() {
     _rcm_cmd=$1
     shift
 
     if [ -d "$SCRIPTLETS_PRIVATE/rcm" ]; then
-        "$_rcm_cmd" -d "$SCRIPTLETS_PRIVATE/rcm" -d "$DOTFILES" "$@"
+        DOTFILES_DIRS="$SCRIPTLETS_PRIVATE/rcm $DOTFILES" \
+            "$_rcm_cmd" -d "$SCRIPTLETS_PRIVATE/rcm" -d "$DOTFILES" "$@"
     else
-        "$_rcm_cmd" -d "$DOTFILES" "$@"
+        DOTFILES_DIRS="$DOTFILES" "$_rcm_cmd" -d "$DOTFILES" "$@"
     fi
 }

--- a/rcm/hooks/positron.sh
+++ b/rcm/hooks/positron.sh
@@ -1,0 +1,47 @@
+# Where Positron's command line tool is, and where this repository links it.
+#
+# handbook/install/hooks/README.md
+#
+# Sourced by the hooks in post-up/ and pre-down/, and deliberately not
+# executable: rcm runs every executable file below hooks/post-up and
+# hooks/pre-down, and this file is not one of them.
+
+# Positron ships its command line tool under the name VS Code gives it, inside
+# the bundle, where it cannot be renamed. `positron` is that name taken out of
+# the way of a `code` that may be VS Code's.
+link=$HOME/bin/positron
+
+# The bundle. A per-user install is looked at first, being the more specific of
+# the two places macOS puts an application; SCRIPTLETS_POSITRON_APP names one
+# bundle instead of both, and is how the check drives these hooks.
+positron_cli() {
+    if [ -n "${SCRIPTLETS_POSITRON_APP:-}" ]; then
+        _positron_cli_in "$SCRIPTLETS_POSITRON_APP"
+    else
+        _positron_cli_in "$HOME/Applications/Positron.app" /Applications/Positron.app
+    fi
+}
+
+# _positron_cli_in BUNDLE... -- the first tool that is there, or nothing.
+_positron_cli_in() {
+    for _app do
+        _cli=$_app/Contents/Resources/app/bin/code
+        if [ -x "$_cli" ]; then
+            printf '%s\n' "$_cli"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Whether $link is one of ours: a symbolic link into a Positron.app, rather
+# than a file the account put there under a name we happen to want.
+positron_link_is_ours() {
+    [ -L "$link" ] || return 1
+
+    case $(readlink "$link") in
+    */Positron.app/Contents/Resources/app/bin/code) return 0 ;;
+    esac
+
+    return 1
+}

--- a/rcm/hooks/post-up/positron
+++ b/rcm/hooks/post-up/positron
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Link Positron's command line tool into ~/bin, on a macOS account that has it.
+#
+# handbook/install/hooks/README.md
+
+set -eu
+
+. "$(dirname -- "$0")/../positron.sh"
+
+# Every path below is inside an application bundle macOS alone has.
+[ "$(uname -s)" = Darwin ] || exit 0
+
+if ! cli=$(positron_cli); then
+    # No bundle, so no reason for a link into one. A link of ours that still
+    # resolves is left alone -- the tool it points at is there, whatever this
+    # run was told to look for.
+    if positron_link_is_ours && [ ! -e "$link" ]; then
+        echo "removing $link: the Positron.app it pointed into is gone"
+        rm -f "$link"
+    fi
+    exit 0
+fi
+
+# Already right: the common case, and it says nothing.
+if [ -L "$link" ] && [ "$(readlink "$link")" = "$cli" ]; then
+    exit 0
+fi
+
+# Anything else in the way belongs to the account. rcm asks before replacing a
+# file it did not create; this hook cannot ask -- an install must not wait at a
+# prompt -- so it keeps what is there and says so.
+if [ -e "$link" ] || [ -L "$link" ]; then
+    if ! positron_link_is_ours; then
+        echo "$link exists and is not ours; leaving it alone" >&2
+        exit 0
+    fi
+fi
+
+# ~/bin is there by now -- rcm has linked the scripts into it before this hook
+# runs -- but not when the hook is run by hand.
+mkdir -p "$(dirname -- "$link")"
+
+# rm first rather than `ln -sfn`: -n is not POSIX, and without it a link that
+# points at a directory would be followed into rather than replaced.
+rm -f "$link"
+ln -s "$cli" "$link"
+echo "linked $link -> $cli"

--- a/rcm/hooks/pre-down/positron
+++ b/rcm/hooks/pre-down/positron
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Take the ~/bin/positron link away again, before rcm unlinks the rest.
+#
+# handbook/install/hooks/README.md
+
+set -eu
+
+. "$(dirname -- "$0")/../positron.sh"
+
+# No platform test here: what identifies the link is where it points, and only
+# the machine that has a Positron.app ever got one. Before rather than after,
+# so that ~/bin is empty by the time rcm prunes the directories it empties.
+if positron_link_is_ours; then
+    echo "removing $link"
+    rm -f "$link"
+fi

--- a/rcm/rcrc
+++ b/rcm/rcrc
@@ -11,7 +11,12 @@ SCRIPTLETS_PRIVATE="${SCRIPTLETS_PRIVATE:-$HOME/git/scriptlets-private}"
 # order that lets a sidecar override rather than be silently ignored. A
 # directory that is not there is skipped, so naming it unconditionally costs a
 # machine without a sidecar nothing.
-DOTFILES_DIRS="$SCRIPTLETS_PRIVATE/rcm $HOME/git/scriptlets/rcm"
+#
+# A value already in the environment wins, and that is how the tasks name the
+# trees they also pass to rcm with -d, from a clone anywhere (mise-tasks/lib.sh
+# says why both are needed). What is set here is what a bare `rcup` or `lsrc`
+# gets.
+DOTFILES_DIRS="${DOTFILES_DIRS:-$SCRIPTLETS_PRIVATE/rcm $HOME/git/scriptlets/rcm}"
 
 # Names that must *not* gain a leading dot. Everything else in the dotfiles
 # directory does: `bashrc` becomes ~/.bashrc, `ssh/config` becomes

--- a/tests/checks/78-positron.sh
+++ b/tests/checks/78-positron.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+# The pair of rcm hooks that keeps ~/bin/positron pointing at Positron's
+# command line tool (handbook/install/hooks/README.md).
+#
+# Against a bundle built here rather than the real one: Positron is macOS-only
+# and installed on neither CI runner, so a check that waited for it would never
+# run. SCRIPTLETS_POSITRON_APP names the bundle, a stub `uname` says Darwin
+# where the machine does not, and HOME is a directory of this check's own --
+# the throw-away home is what the other checks read, and ~/bin is in it.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+hooks=$REPO/rcm/hooks
+
+work=$HOME/positron-check
+rm -rf "$work"
+mkdir -p "$work/bin" "$work/home"
+
+app=$work/Applications/Positron.app
+cli=$app/Contents/Resources/app/bin/code
+link=$work/home/bin/positron
+
+mkdir -p "${cli%/*}"
+cat >"$cli" <<'STUB'
+#!/bin/sh
+echo "positron-cli $*"
+STUB
+chmod +x "$cli"
+
+# Enough of uname for the one question the hook asks it.
+cat >"$work/bin/uname" <<'STUB'
+#!/bin/sh
+[ "$1" = -s ] || exit 1
+echo Darwin
+STUB
+chmod +x "$work/bin/uname"
+
+# run HOOK -- the hook, on a Darwin that has the bundle, with $output and
+# $status. `env` rather than an exported PATH, so the stub is in front of the
+# real uname for the hook alone.
+run() {
+    output=$(PATH="$work/bin:$PATH" HOME=$work/home \
+        SCRIPTLETS_POSITRON_APP=$app "$hooks/$1" 2>&1)
+    status=$?
+}
+
+# --- off macOS --------------------------------------------------------------
+
+# The hook is reached on every install, on every platform, and everything below
+# this line is inside a bundle only macOS has.
+if [ "$(uname -s)" = Darwin ]; then
+    skip "off macOS the hook does nothing: this machine is macOS"
+else
+    output=$(HOME=$work/home SCRIPTLETS_POSITRON_APP=$app \
+        "$hooks/post-up/positron" 2>&1)
+    status=$?
+    assert_equal "off macOS the hook succeeds" "0" "$status"
+    assert_equal "off macOS the hook says nothing" "" "$output"
+    if [ -e "$link" ] || [ -L "$link" ]; then
+        fail "off macOS the hook links nothing" "$(ls -l "$link" 2>&1)"
+    else
+        pass "off macOS the hook links nothing"
+    fi
+fi
+
+# --- linking ----------------------------------------------------------------
+
+run post-up/positron
+assert_equal "the hook succeeds" "0" "$status"
+assert_equal "the link points at the tool in the bundle" \
+    "$cli" "$(readlink "$link" 2>&1)"
+assert_match "and the hook says what it linked" "linked *positron -> *code" \
+    "$output"
+
+# The name is the point: the tool inside the bundle is called `code`, which is
+# VS Code's, and reaching Positron by that name would mean shadowing it.
+assert_equal "the tool answers to the name it is linked under" \
+    "positron-cli --version" "$(PATH="$work/home/bin:$PATH" positron --version)"
+
+run post-up/positron
+assert_equal "a second run succeeds" "0" "$status"
+assert_equal "a second run says nothing" "" "$output"
+assert_equal "and leaves the link alone" "$cli" "$(readlink "$link" 2>&1)"
+
+# --- what it will not touch -------------------------------------------------
+
+rm -f "$link"
+echo 'mine' >"$link"
+
+run post-up/positron
+assert_equal "a file of the account's own is left alone" \
+    "mine" "$(cat "$link")"
+assert_equal "and the hook still succeeds" "0" "$status"
+assert_match "and says why it did nothing" "*not ours*" "$output"
+
+output=$(HOME=$work/home "$hooks/pre-down/positron" 2>&1)
+assert_equal "uninstalling leaves it alone too" "mine" "$(cat "$link")"
+
+rm -f "$link"
+
+# --- the bundle going away --------------------------------------------------
+
+run post-up/positron
+rm -rf "$work/Applications"
+
+run post-up/positron
+if [ -L "$link" ]; then
+    fail "a link into a bundle that is gone is removed" "$(ls -l "$link" 2>&1)"
+else
+    pass "a link into a bundle that is gone is removed"
+fi
+assert_match "and the hook says so" "removing *" "$output"
+
+mkdir -p "${cli%/*}"
+cat >"$cli" <<'STUB'
+#!/bin/sh
+echo "positron-cli $*"
+STUB
+chmod +x "$cli"
+
+# --- uninstalling -----------------------------------------------------------
+
+run post-up/positron
+
+output=$(HOME=$work/home "$hooks/pre-down/positron" 2>&1)
+status=$?
+assert_equal "uninstalling succeeds" "0" "$status"
+if [ -L "$link" ]; then
+    fail "uninstalling removes the link" "$(ls -l "$link" 2>&1)"
+else
+    pass "uninstalling removes the link"
+fi
+
+# --- through the tasks ------------------------------------------------------
+
+# Everything above runs the hooks directly, which says nothing about whether
+# rcm reaches them: it runs the executable files below hooks/post-up and
+# hooks/pre-down of the trees named in DOTFILES_DIRS, and that list is not the
+# one -d gives it (handbook/install/hooks/README.md).
+cycle=$work/cycle
+mkdir -p "$cycle"
+
+task() {
+    PATH="$work/bin:$PATH" HOME=$cycle SCRIPTLETS_POSITRON_APP=$app \
+        MISE_TRUSTED_CONFIG_PATHS=$REPO mise -q -C "$REPO" run "$1" \
+        >/dev/null 2>&1 </dev/null
+}
+
+if task install; then
+    assert_equal "mise run install links the tool" \
+        "$cli" "$(readlink "$cycle/bin/positron" 2>&1)"
+else
+    fail "mise run install links the tool" "the task failed"
+fi
+
+if task uninstall; then
+    if [ -e "$cycle/bin/positron" ] || [ -L "$cycle/bin/positron" ]; then
+        fail "mise run uninstall takes the link away again" \
+            "$(ls -l "$cycle/bin/positron" 2>&1)"
+    else
+        pass "mise run uninstall takes the link away again"
+    fi
+else
+    fail "mise run uninstall takes the link away again" "the task failed"
+fi
+
+# --- what rcm needs of the files --------------------------------------------
+
+# rcm runs the executable files below hooks/pre-up, hooks/post-up and their
+# down counterparts, and passes over the rest without a word: a hook that lost
+# its permission bit would stop running and nothing would say so.
+not_executable=
+for hook in "$hooks"/*-*/*; do
+    [ -x "$hook" ] || not_executable="$not_executable ${hook#$REPO/}"
+done
+
+if [ -z "$not_executable" ]; then
+    pass "every hook is executable"
+else
+    fail "every hook is executable" "not executable:$not_executable"
+fi
+
+# hooks/ is rcm's own name for that directory, and it installs nothing from it
+# -- the shared file beside the hooks would otherwise land in the home
+# directory as ~/.hooks/positron.sh.
+if [ -e "$HOME/.hooks" ]; then
+    fail "the hooks directory is not installed" "$(ls -ld "$HOME/.hooks" 2>&1)"
+else
+    pass "the hooks directory is not installed"
+fi
+
+rm -rf "$work"


### PR DESCRIPTION
Positron ships its command line tool inside the application bundle,
under the name it inherited from VS Code:

```console
$ pwd
/Applications/Positron.app/Contents/Resources/app/bin
$ ls -l
-rwxr-xr-x@ 1 kirill  admin  1164 Jul  9 05:27 code
```

It cannot be renamed where it sits,
so putting that directory on the `PATH` puts a second `code` there —
one that shadows VS Code's, or is shadowed by it.
A symbolic link under a name of our choosing is the way out,
and reaching the tool through one is a case it handles:
[its first act is to follow the link back to the bundle](https://github.com/posit-dev/positron/blob/main/resources/darwin/bin/code.sh).

The link's target is an absolute path outside the repository,
present on some accounts and not others,
so it is a decision for the machine rather than a file under `rcm/` —
an rcm hook rather than a checked-in link.

## What this adds

- [`rcm/hooks/post-up/positron`](https://github.com/krlmlr/scriptlets/blob/claude/positron-symlink-hook-macos-moxo02/rcm/hooks/post-up/positron) —
  after `mise run install` links everything else,
  points `~/bin/positron` at the tool in the bundle,
  on a macOS account that has one.
  `$HOME/Applications/Positron.app` is preferred over `/Applications/Positron.app`,
  and `SCRIPTLETS_POSITRON_APP` names one bundle instead of both.
- [`rcm/hooks/pre-down/positron`](https://github.com/krlmlr/scriptlets/blob/claude/positron-symlink-hook-macos-moxo02/rcm/hooks/pre-down/positron) —
  `mise run uninstall` takes the link away again,
  so the one thing here that rcm did not create does not become a stray.
- A `~/bin/positron` that is not a symbolic link into a `Positron.app`
  belongs to the account: the hook keeps it and says so.
  A link of ours whose bundle is gone is removed on the next install.
- Silence is the normal case — nothing is printed
  when the link is already right, or when there is no bundle at all.

## The rcm asymmetry this uncovered

`rcup` assigns `DOTFILES_DIRS` from the `-d` it is given; `rcdn` keeps `-d`
to itself (checked against rcm 1.3.4). Both look for hooks below
`DOTFILES_DIRS`, so an uninstall run from a clone outside `~/git/scriptlets`
would have unlinked one tree and run another tree's hooks, or none at all.
`rcm_run` now names the trees in the environment as well as in `-d`, and
`rcm/rcrc` defers to a value already set — which is also what keeps the
invariant `mise-tasks/lib.sh` already claims: install and uninstall cannot
come apart over which trees they act on.

## Tests

`tests/checks/78-positron.sh` builds a bundle of its own and stubs `uname`,
because Positron is macOS-only and installed on neither CI runner.
It covers the no-op off macOS, linking, the silent second run, the file it
refuses to replace, the bundle that goes away, and removal on the way out —
and drives one install and uninstall through the tasks, for the part that
running the hooks by hand cannot show: that rcm reaches them at all.

`mise run test` passes end to end on Linux here.

## Documentation

`handbook/install/hooks/README.md` is the new leaf: rcm's hook mechanism,
the Positron link, and the limits (the link follows an install, not the
application; Positron is the only bundle here). `layout/mapping/`,
`layout/private/`, `install/tasks/`, `testing/`, the glossary and the root
README are updated to point at it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjD4YZ1PMQ6ExeqBs4QAkw)_