### PR TITLE
docs(`nosleep`): say that nothing takes the flag back on its own — and revisit Sleepless later

### DIFF
--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -162,6 +162,11 @@ are the two spellings at three letters,
 for the times both are typed often.
 Installed on macOS only, since `pmset` is macOS's.
 
+Nothing takes the flag back on its own:
+sleep stays forbidden until something allows it again,
+through a closed lid and down to an empty battery.
+There is no timer here, and no floor under the battery.
+
 `mise run nosleep-grant` retires the password prompt
 ([`install/tasks/`](/handbook/install/tasks/README.md)):
 it writes a rule to `/etc/sudoers.d/nosleep`


### PR DESCRIPTION
Draft on purpose: this is the reminder, and it stays open until Sleepless is old enough to judge.

**The reminder.** [Sleepless](https://github.com/Aboudjem/Sleepless) (MIT, macOS menu bar) drives the same `pmset -a disablesleep` flag `nosleep` writes, and adds the two things `nosleep` has no answer for: an auto-off timer and a battery-floor cutoff. It is the only open-source tool found that clears the bar this repo's tool exists for — lid closed, no external display, on battery — without being a `caffeinate` wrapper. It is also very young, with no track record for a tool that holds a machine awake unattended, so nothing is adopted here now. Worth re-investigating in a few months: either as something to install alongside `slf`/`sla`, or as prior art for growing `nosleep` a `slf 2h` and a battery floor of its own.

**Also surveyed, and not the answer.** Amphetamine clears the bar too (it lifts Apple's clamshell requirements through a public API), but on Apple Silicon laptops a closed-display session since 5.3 wants a helper script plus admin authentication per session — or the separately downloaded Power Protect script and config file to avoid the prompt. That is the same bargain as `mise run nosleep-grant`, with a wider grant and a GUI app in the path; control from a script is `osascript` against a running app, and sessions replace each other rather than being idempotent. KeepingYouAwake, Theine, Owly, Lungo and the rest wrap `caffeinate`, which suppresses the idle timer but cannot override the hardware lid-close trigger. InsomniaX and the NoSleep kext are dead and not viable on Apple Silicon.

**The diff.** One paragraph in [`handbook/tools/`](https://github.com/krlmlr/scriptlets/blob/claude/amphetamine-slf-sla-alternatives-s2akab/handbook/tools/README.md), stating the absence: sleep stays forbidden until something allows it again, through a closed lid and down to an empty battery — no timer, no battery floor. That is a fact about today, which the tree owns as a limit; the survey above is a rejected alternative and stays in the pull request, where [`meta/authoring/`](https://github.com/krlmlr/scriptlets/blob/main/handbook/meta/authoring/README.md) puts it. No behaviour changes, so no check changes; `tests/checks/05-handbook.sh` passes.

If a stale draft PR is the wrong holder for this, an issue is the repo's own answer for work not done — say the word and I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYoTDCqkFkTMSrmcGFxtCS


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYoTDCqkFkTMSrmcGFxtCS)_