### PR TITLE
feat(git): resolve conflicts with the `zdiff3` conflict style

### DIFF
--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -1,6 +1,7 @@
 [rerere]
 	enabled = true
 [merge]
+	# Needs Git >= 2.35
 	conflictstyle = zdiff3
 	ff = false
 [diff]

--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -1,7 +1,7 @@
 [rerere]
 	enabled = true
 [merge]
-	conflictstyle = diff3
+	conflictstyle = zdiff3
 	ff = false
 [diff]
 	algorithm = histogram


### PR DESCRIPTION
Switches `merge.conflictstyle` in `rcm/gitconfig` from `diff3` to `zdiff3`.

`zdiff3` keeps everything `diff3` gives (the common ancestor shown in a `|||||||` section) but additionally hoists lines that both sides changed identically out of the conflict region, so the remaining hunk shows only what actually diverged. Conflicts get smaller and easier to read; nothing else about merge behaviour changes.

`zdiff3` requires Git 2.35 or newer (released January 2022). On an older Git the value is unknown and Git falls back to the `merge` style, losing the ancestor section — worth knowing if this config is ever used on a very old machine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01963oKWoykqAYZ1cumETGs6)_