### PR TITLE
feat: open pull requests and set repository options with `gh`

### DIFF
--- a/handbook/install/prerequisites/README.md
+++ b/handbook/install/prerequisites/README.md
@@ -11,10 +11,12 @@ and what individual scripts assume beyond that.
 and only `import` and the tests need it
 ([`install/tasks/`](/handbook/install/tasks/README.md) has the split).
 
-The [GitHub CLI](https://cli.github.com) is needed by one script alone:
-[`bootstrap-private`](/bootstrap-private) creates a repository with it,
-and says what to do by hand where it is missing
-([`layout/private/`](/handbook/layout/private/README.md)).
+The [GitHub CLI](https://cli.github.com) is what everything here says to
+GitHub with: [`bootstrap-private`](/bootstrap-private) creates a
+repository with it, and says what to do by hand where it is missing
+([`layout/private/`](/handbook/layout/private/README.md));
+`git-pr` and `gh-repo-setup` refuse to run without it
+([`tools/`](/handbook/tools/README.md)).
 
 Putting `~/bin` on the `PATH` is not among the things left to you:
 the shipped profiles do it, on macOS as well as on Ubuntu

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -141,6 +141,16 @@ and they run in name order:
   remotes of a throw-away repository
   and leaves every other remote alone,
   through `~/bin` and through the `git sr` alias alike.
+- `71-git-pr`: what `git pr` would run, read off its `--dry-run`:
+  the title is the first commit's subject rather than the last,
+  the issue closed is the one the branch name numbers,
+  and the trailing field of that name stays a suffix.
+- `72-gh-repo-setup`: the owner and name `gh-repo-setup` recovers from
+  every spelling a remote comes in,
+  which remote it asks first,
+  and the options it sets with and without auto-merge.
+  Neither check reaches GitHub, and neither needs `gh` installed:
+  `--dry-run` puts the commands on stdout instead of running them.
 - `75-h`: `h` runs the command in every repository below the current
   directory, and each line of output says which one it came from.
   Both halves matter:

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -148,7 +148,7 @@ and they run in name order:
 - `72-gh-repo-setup`: the owner and name `gh-repo-setup` recovers from
   every spelling a remote comes in,
   which remote it asks first,
-  and the options it sets with and without auto-merge.
+  and the three options it sets.
   Neither check reaches GitHub, and neither needs `gh` installed:
   `--dry-run` puts the commands on stdout instead of running them.
 - `75-h`: `h` runs the command in every repository below the current

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -84,11 +84,10 @@ and is what the `pra` alias adds;
 **`gh-repo-setup`** — set `gh`'s default repository, and GitHub's merge
 options for the repository of the current directory:
 a pull request that can be brought up to date from the web,
-and a branch that goes when it merges.
-`-a` / `--auto-merge` adds auto-merge,
-which belongs to a repository that merges its own pull requests rather
-than to a fork,
-so the run after `gh repo fork` is the one without it.
+a branch that goes when it merges, and auto-merge.
+All three are settings a repository offers rather than performs,
+so the run after `gh repo fork` sets the same three:
+a fork that never merges a pull request is no reason to leave one off.
 Which repository that is comes from `upstream`,
 or from `origin` where there is no `upstream`,
 spelled as owner and name because `gh repo edit` refuses a bare one.

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -65,6 +65,34 @@ non-repository case under review below.
 
 ### Git, one repository at a time
 
+**`git-pr`** — open the pull request for the current branch, or update
+the one that is already there: push the branch, let `gh` fill the body
+from its commits, then correct the title to the first commit's subject
+and close the issue the branch is named after.
+The title needs correcting because `gh pr create --fill` reaches for the
+branch name once a branch has more than one commit;
+the issue comes out of that name, which is split on dashes,
+its last field dropped as the suffix that keeps two branches about the
+same issue apart,
+and every field that is a number turned into a `Closes` line.
+The branch it opens against is what the remote says its default branch
+is — `upstream` before `origin`, since a fork's `origin` is the fork.
+`-a` / `--auto-merge` ends in `gh pr merge --auto --squash`,
+and is what the `pra` alias adds;
+`-n` / `--dry-run` prints the commands instead of running them.
+
+**`gh-repo-setup`** — set `gh`'s default repository, and GitHub's merge
+options for the repository of the current directory:
+a pull request that can be brought up to date from the web,
+and a branch that goes when it merges.
+`-a` / `--auto-merge` adds auto-merge,
+which belongs to a repository that merges its own pull requests rather
+than to a fork,
+so the run after `gh repo fork` is the one without it.
+Which repository that is comes from `upstream`,
+or from `origin` where there is no `upstream`,
+spelled as owner and name because `gh repo edit` refuses a bare one.
+
 **`git-mmv`** — write `git mmv` to move several Git-controlled files
 at once, with the usual `mmv` syntax.
 

--- a/rcm/bin/gh-repo-setup
+++ b/rcm/bin/gh-repo-setup
@@ -1,43 +1,40 @@
 #!/bin/sh
 # Point `gh` at the repository this working copy belongs to, and set the three
 # merge options every repository here wants: a pull request that can be brought
-# up to date from the web, a branch that goes when it merges, and -- where the
-# repository is one this account merges into rather than sends to -- auto-merge.
+# up to date from the web, a branch that goes when it merges, and auto-merge.
 #
 # Run it after a fresh clone, and again after `gh repo fork`, which leaves the
-# fork with GitHub's defaults; the fork is not where pull requests merge, so
-# that run is the one without --auto-merge.
+# fork with GitHub's defaults. All three are settings a repository offers
+# rather than performs, so a fork that never merges a pull request is no reason
+# to leave any of them off.
 set -eu
 
 dry_run=0
-auto_merge=0
 
 usage() {
     cat <<'EOF'
-Usage: gh-repo-setup [-n|--dry-run] [-a|--auto-merge]
+Usage: gh-repo-setup [-n|--dry-run]
 
 Set `gh`'s default repository and GitHub's merge options for the repository
 of the current directory:
 
   gh repo set-default <owner/repo>
-  gh repo edit <owner/repo> --allow-update-branch --delete-branch-on-merge
+  gh repo edit <owner/repo> --allow-update-branch --delete-branch-on-merge \
+      --enable-auto-merge
 
 The repository is the one `upstream` points at, or `origin` where there is
 no `upstream` remote, spelled as owner and name because `gh repo edit`
 refuses a bare one.
 
 Options:
-  -n, --dry-run     print the commands instead of running them
-  -a, --auto-merge  add --enable-auto-merge, for a repository that merges
-                    its own pull requests
-  -h, --help        show this help
+  -n, --dry-run  print the commands instead of running them
+  -h, --help     show this help
 EOF
 }
 
 while [ $# -gt 0 ]; do
     case "$1" in
     -n | --dry-run) dry_run=1 ;;
-    -a | --auto-merge) auto_merge=1 ;;
     -h | --help)
         usage
         exit 0
@@ -114,9 +111,4 @@ if [ "$dry_run" -eq 0 ] && ! command -v gh >/dev/null; then
 fi
 
 run gh repo set-default "$slug"
-
-if [ "$auto_merge" -eq 1 ]; then
-    run gh repo edit "$slug" --allow-update-branch --delete-branch-on-merge --enable-auto-merge
-else
-    run gh repo edit "$slug" --allow-update-branch --delete-branch-on-merge
-fi
+run gh repo edit "$slug" --allow-update-branch --delete-branch-on-merge --enable-auto-merge

--- a/rcm/bin/gh-repo-setup
+++ b/rcm/bin/gh-repo-setup
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Point `gh` at the repository this working copy belongs to, and set the three
+# merge options every repository here wants: a pull request that can be brought
+# up to date from the web, a branch that goes when it merges, and -- where the
+# repository is one this account merges into rather than sends to -- auto-merge.
+#
+# Run it after a fresh clone, and again after `gh repo fork`, which leaves the
+# fork with GitHub's defaults; the fork is not where pull requests merge, so
+# that run is the one without --auto-merge.
+set -eu
+
+dry_run=0
+auto_merge=0
+
+usage() {
+    cat <<'EOF'
+Usage: gh-repo-setup [-n|--dry-run] [-a|--auto-merge]
+
+Set `gh`'s default repository and GitHub's merge options for the repository
+of the current directory:
+
+  gh repo set-default <owner/repo>
+  gh repo edit <owner/repo> --allow-update-branch --delete-branch-on-merge
+
+The repository is the one `upstream` points at, or `origin` where there is
+no `upstream` remote, spelled as owner and name because `gh repo edit`
+refuses a bare one.
+
+Options:
+  -n, --dry-run     print the commands instead of running them
+  -a, --auto-merge  add --enable-auto-merge, for a repository that merges
+                    its own pull requests
+  -h, --help        show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -n | --dry-run) dry_run=1 ;;
+    -a | --auto-merge) auto_merge=1 ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        printf 'gh-repo-setup: unknown option: %s\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Says "fatal: not a git repository" in git's own words, and stops.
+git rev-parse --git-dir >/dev/null
+
+url=
+for remote in upstream origin; do
+    url=$(git remote get-url "$remote" 2>/dev/null || true)
+    if [ -n "$url" ]; then
+        break
+    fi
+done
+
+if [ -z "$url" ]; then
+    printf 'gh-repo-setup: this repository has no upstream or origin remote\n' >&2
+    exit 1
+fi
+
+# owner/repo out of either spelling a remote comes in --
+# git@github.com:owner/repo.git, https://github.com/owner/repo.git, and the
+# same two without the suffix. The last two path components are the answer,
+# whatever stands in front of them.
+slug=$(printf '%s\n' "$url" |
+    sed -e 's#[.]git$##' -e 's#/$##' -e 's#^.*[:/]\([^/][^/]*/[^/][^/]*\)$#\1#')
+
+case $slug in
+*/*[!/]) ;;
+*)
+    printf 'gh-repo-setup: cannot read owner/repo out of %s\n' "$url" >&2
+    exit 1
+    ;;
+esac
+
+# quote ARGUMENT -- as the shell would need it written, so that a --dry-run
+# line can be pasted back into a terminal.
+quote() {
+    case $1 in
+    '' | *[!A-Za-z0-9._/=:@#-]*)
+        printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+        ;;
+    *)
+        printf '%s' "$1"
+        ;;
+    esac
+}
+
+# run COMMAND... -- or print it, when --dry-run says so.
+run() {
+    if [ "$dry_run" -eq 1 ]; then
+        line=
+        for argument in "$@"; do
+            line="$line $(quote "$argument")"
+        done
+        printf '%s\n' "${line# }"
+    else
+        "$@"
+    fi
+}
+
+if [ "$dry_run" -eq 0 ] && ! command -v gh >/dev/null; then
+    printf 'gh-repo-setup: the GitHub CLI is required: https://cli.github.com\n' >&2
+    exit 1
+fi
+
+run gh repo set-default "$slug"
+
+if [ "$auto_merge" -eq 1 ]; then
+    run gh repo edit "$slug" --allow-update-branch --delete-branch-on-merge --enable-auto-merge
+else
+    run gh repo edit "$slug" --allow-update-branch --delete-branch-on-merge
+fi

--- a/rcm/bin/git-pr
+++ b/rcm/bin/git-pr
@@ -1,0 +1,137 @@
+#!/bin/sh
+# Open the pull request for the current branch, the way this account always
+# opens one: push the branch, let `gh` fill the body from the commits, then
+# correct the two things `--fill` gets wrong for a branch of several commits --
+# the title, which should be the first commit's subject rather than the branch
+# name, and the issue the branch is named after.
+#
+# Re-running updates the title and body of the pull request that is already
+# there, so an amended first commit is one `git pr` away from a matching title.
+set -eu
+
+dry_run=0
+auto_merge=0
+
+usage() {
+    cat <<'EOF'
+Usage: git pr [-n|--dry-run] [-a|--auto-merge]
+
+Open (or update) the pull request for the current branch:
+
+  git push --set-upstream origin HEAD
+  gh pr create --fill
+  gh pr edit --title <first commit subject> [--body <Closes lines>]
+
+The title is the subject of the first commit since the default branch of
+`upstream`, or of `origin` where there is no `upstream` remote.
+
+The body is derived from the branch name: it is split on dashes, the last
+field is dropped as the disambiguating suffix, and every field that is a
+number becomes a `Closes #<number>.` line. A branch name that yields none
+leaves the body `--fill` wrote alone.
+
+Options:
+  -n, --dry-run     print the commands instead of running them
+  -a, --auto-merge  end with `gh pr merge --auto --squash`
+  -h, --help        show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -n | --dry-run) dry_run=1 ;;
+    -a | --auto-merge) auto_merge=1 ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        printf 'git-pr: unknown option: %s\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Says "fatal: not a git repository" in git's own words, and stops.
+git rev-parse --git-dir >/dev/null
+
+# quote ARGUMENT -- as the shell would need it written, so that a --dry-run
+# line can be pasted back into a terminal.
+quote() {
+    case $1 in
+    '' | *[!A-Za-z0-9._/=:@#-]*)
+        printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+        ;;
+    *)
+        printf '%s' "$1"
+        ;;
+    esac
+}
+
+# run COMMAND... -- or print it, when --dry-run says so.
+run() {
+    if [ "$dry_run" -eq 1 ]; then
+        line=
+        for argument in "$@"; do
+            line="$line $(quote "$argument")"
+        done
+        printf '%s\n' "${line# }"
+    else
+        "$@"
+    fi
+}
+
+# The branch every pull request here is opened against: what the remote itself
+# says its default branch is, `upstream` before `origin` because a fork's
+# `origin` is the fork. `git remote set-head <remote> --auto` writes it.
+base=
+for remote in upstream origin; do
+    base=$(git symbolic-ref --short "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+    if [ -n "$base" ]; then
+        break
+    fi
+done
+
+if [ -z "$base" ]; then
+    printf 'git-pr: no default branch known for upstream or origin --\n' >&2
+    printf '        run `git remote set-head origin --auto`\n' >&2
+    exit 1
+fi
+
+title=$(git log --reverse --format=%s "$base..HEAD" | head -n 1)
+
+if [ -z "$title" ]; then
+    printf 'git-pr: no commits between %s and HEAD\n' "$base" >&2
+    exit 1
+fi
+
+# The trailing field of a branch name is the suffix that keeps two branches
+# about the same issue apart, so it never becomes a `Closes` line, however
+# numeric it looks.
+body=$(git rev-parse --abbrev-ref HEAD |
+    awk -F- '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/) print "Closes #" $i "." }')
+
+if [ "$dry_run" -eq 0 ] && ! command -v gh >/dev/null; then
+    printf 'git-pr: the GitHub CLI is required: https://cli.github.com\n' >&2
+    exit 1
+fi
+
+run git push --set-upstream origin HEAD
+
+# `--fill` refuses a branch that already has a pull request, and the edit below
+# is exactly what that branch needs, so the create is the step that is skipped.
+if [ "$dry_run" -eq 1 ] || ! gh pr view --json number >/dev/null 2>&1; then
+    run gh pr create --fill
+fi
+
+if [ -n "$body" ]; then
+    run gh pr edit --title "$title" --body "$body"
+else
+    run gh pr edit --title "$title"
+fi
+
+if [ "$auto_merge" -eq 1 ]; then
+    run gh pr merge --auto --squash
+fi

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -124,9 +124,12 @@
 	# https://stackoverflow.com/a/5201642/946850
 	sq = !sh -c 'git reset --soft ${1:-main} && git commit --edit -m$(git log --format=%B --reverse HEAD..HEAD@{1})'
 	sr = ssh-remote
-	# hub
-	pr = !sh -c 'hub pull-request "$@"'
-	prm = !sh -c 'hub pull-request -b main "$@"'
+	# Pull requests: `git pr` is the script in ~/bin, and needs no alias --
+	# a git-<name> on the PATH wins over an alias that spells it, so one
+	# here would never run. `pra` adds the auto-merge, and `prm` warns,
+	# then forwards: the script opens against the default branch already.
+	pra = pr --auto-merge
+	prm = "!echo 'warning: prm is now pr' >&2; git pr"
 	# ---
 	# stash
 	sts = stash save

--- a/tests/checks/71-git-pr.sh
+++ b/tests/checks/71-git-pr.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# What `git pr` would run, checked without running any of it.
+#
+# `--dry-run` is what makes that possible, and everything worth checking is
+# visible in it: the title comes from the first commit rather than the last,
+# the `Closes` lines come from the branch name, and the trailing field of that
+# name is a suffix rather than an issue number.
+#
+# Nothing here reaches GitHub. The repository is a throw-away one below $HOME,
+# its remote is a name that is never contacted, and the default branch is
+# written into the ref by hand -- `git remote set-head --auto` is the command
+# that would ask the network for it.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+work=$HOME/git-pr-check
+rm -rf "$work"
+git init -q "$work"
+
+git -C "$work" remote add origin git@github.com:krlmlr/scriptlets.git
+git -C "$work" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+
+commit() {
+    printf '%s\n' "$2" >"$work/file"
+    git -C "$work" add file
+    git -C "$work" commit -q -m "$1"
+}
+
+commit "base" one
+git -C "$work" update-ref refs/remotes/origin/main HEAD
+
+run() {
+    output=$(git -C "$work" pr --dry-run "$@" 2>&1)
+    status=$?
+}
+
+# --- a branch with an issue number ------------------------------------------
+
+git -C "$work" switch -q -c topic-41-qkxmvp
+commit "feat: the subject that becomes the title" two
+commit "the second commit, which must not" three
+
+run
+assert_equal "--dry-run succeeds" "0" "$status"
+assert_match "the branch is pushed with its upstream set" \
+    "*git push --set-upstream origin HEAD*" "$output"
+assert_match "the pull request is filled from the commits" \
+    "*gh pr create --fill*" "$output"
+assert_match "the title is the first commit's subject" \
+    "*--title 'feat: the subject that becomes the title'*" "$output"
+assert_match "the issue in the branch name is closed" "*--body 'Closes #41.'*" \
+    "$output"
+assert_match "and nothing is merged without being asked" "" \
+    "$(printf '%s\n' "$output" | grep 'gh pr merge' || true)"
+
+run --auto-merge
+assert_match "--auto-merge ends in an auto-merge" "*gh pr merge --auto --squash*" \
+    "$output"
+
+# --- a branch without one ---------------------------------------------------
+
+# The body `--fill` wrote from the commits is worth more than an empty one, so
+# a branch name that yields no `Closes` line leaves it alone.
+git -C "$work" switch -q -c a-branch-named-for-nothing refs/remotes/origin/main
+commit "fix: something the branch name does not number" four
+
+run
+assert_match "a name without a number still gets a title" "*--title 'fix:*" \
+    "$output"
+assert_equal "and no body at all" "0" \
+    "$(printf '%s\n' "$output" | grep -c -- '--body' | tr -d ' ')"
+
+# The last field disambiguates two branches about the same issue, so it is a
+# suffix even when it is a number.
+git -C "$work" switch -q -c topic-2 refs/remotes/origin/main
+commit "docs: a branch whose last field is a number" five
+
+run
+assert_equal "the trailing field is a suffix, not an issue" "" \
+    "$(printf '%s\n' "$output" | grep -o -- '--body.*' || true)"
+
+# --- where it refuses -------------------------------------------------------
+
+run --nonsense
+assert_equal "an unknown option fails" "1" "$status"
+assert_match "an unknown option prints the usage" "*Usage:*" "$output"
+
+git -C "$work" switch -q --detach refs/remotes/origin/main
+output=$(git -C "$work" pr --dry-run 2>&1)
+status=$?
+assert_equal "a branch with no commits of its own fails" "1" "$status"
+assert_match "and says so" "*no commits*" "$output"

--- a/tests/checks/71-git-pr.sh
+++ b/tests/checks/71-git-pr.sh
@@ -18,6 +18,14 @@ set -u
 PATH="$HOME/bin:$PATH"
 export PATH
 
+# The throw-away home has no git identity, and neither does a CI runner: the
+# repository's ~/.gitconfig only carries one for an account with a tag.
+GIT_AUTHOR_NAME=check
+GIT_AUTHOR_EMAIL=check@example
+GIT_COMMITTER_NAME=check
+GIT_COMMITTER_EMAIL=check@example
+export GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+
 work=$HOME/git-pr-check
 rm -rf "$work"
 git init -q "$work"

--- a/tests/checks/72-gh-repo-setup.sh
+++ b/tests/checks/72-gh-repo-setup.sh
@@ -64,11 +64,7 @@ assert_match "the repository is addressed by owner and name" \
 assert_match "a pull request can be updated from the web" "*--allow-update-branch*" \
     "$output"
 assert_match "a merged branch goes" "*--delete-branch-on-merge*" "$output"
-assert_equal "and auto-merge stays off until it is asked for" "" \
-    "$(printf '%s\n' "$output" | grep -o -- '--enable-auto-merge' || true)"
-
-run --auto-merge
-assert_match "--auto-merge enables it" "*--enable-auto-merge*" "$output"
+assert_match "and auto-merge is offered" "*--enable-auto-merge*" "$output"
 
 # --- where it refuses -------------------------------------------------------
 

--- a/tests/checks/72-gh-repo-setup.sh
+++ b/tests/checks/72-gh-repo-setup.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# What `gh-repo-setup` would run, checked without running any of it.
+#
+# The logic under the two `gh` lines is the reading of a remote URL: which
+# remote is asked, and how owner and name are recovered from every spelling a
+# remote comes in. `--dry-run` puts both on stdout, so the check reads them
+# there rather than at GitHub.
+#
+# Nothing here reaches GitHub, and nothing here needs `gh` installed: the
+# repository is a throw-away one below $HOME, and its remotes are never
+# contacted.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+work=$HOME/gh-repo-setup-check
+rm -rf "$work"
+git init -q "$work"
+
+run() {
+    output=$(cd "$work" && gh-repo-setup --dry-run "$@" 2>&1)
+    status=$?
+}
+
+# slug_of URL -- what the script makes of a remote spelled that way.
+slug_of() {
+    git -C "$work" remote remove origin 2>/dev/null || true
+    git -C "$work" remote add origin "$1"
+    run
+    printf '%s\n' "$output" | sed -n 's/^gh repo set-default //p'
+}
+
+# --- reading the remote -----------------------------------------------------
+
+assert_equal "an SSH remote" "krlmlr/scriptlets" \
+    "$(slug_of git@github.com:krlmlr/scriptlets.git)"
+assert_equal "an HTTPS remote" "krlmlr/scriptlets" \
+    "$(slug_of https://github.com/krlmlr/scriptlets.git)"
+assert_equal "an HTTPS remote carrying a credential" "krlmlr/scriptlets" \
+    "$(slug_of https://token@github.com/krlmlr/scriptlets)"
+assert_equal "an ssh:// remote" "krlmlr/scriptlets" \
+    "$(slug_of ssh://git@github.com/krlmlr/scriptlets.git)"
+assert_equal "a remote without the .git suffix" "krlmlr/scriptlets" \
+    "$(slug_of git@github.com:krlmlr/scriptlets)"
+
+# A fork's `origin` is the fork, so the repository to configure is what
+# `upstream` names wherever there is one.
+git -C "$work" remote add upstream git@github.com:cynkra/scriptlets.git
+run
+assert_match "upstream wins over origin" "*gh repo set-default cynkra/scriptlets*" \
+    "$output"
+git -C "$work" remote remove upstream
+
+# --- the options it sets ----------------------------------------------------
+
+run
+assert_equal "--dry-run succeeds" "0" "$status"
+assert_match "the repository is addressed by owner and name" \
+    "*gh repo edit krlmlr/scriptlets *" "$output"
+assert_match "a pull request can be updated from the web" "*--allow-update-branch*" \
+    "$output"
+assert_match "a merged branch goes" "*--delete-branch-on-merge*" "$output"
+assert_equal "and auto-merge stays off until it is asked for" "" \
+    "$(printf '%s\n' "$output" | grep -o -- '--enable-auto-merge' || true)"
+
+run --auto-merge
+assert_match "--auto-merge enables it" "*--enable-auto-merge*" "$output"
+
+# --- where it refuses -------------------------------------------------------
+
+run --nonsense
+assert_equal "an unknown option fails" "1" "$status"
+assert_match "an unknown option prints the usage" "*Usage:*" "$output"
+
+bare=$HOME/gh-repo-setup-check-remoteless
+rm -rf "$bare"
+git init -q "$bare"
+output=$(cd "$bare" && gh-repo-setup --dry-run 2>&1)
+status=$?
+assert_equal "a repository without remotes fails" "1" "$status"
+assert_match "and says which remotes it looked for" "*upstream or origin*" "$output"


### PR DESCRIPTION
Retires `hub` and closes #41, which are the same job from two ends:
the pull-request aliases were the last thing here that called `hub`,
and the repository options in the issue are what make the auto-merge half of that flow work.

Closes #41.

## `git-pr`

A script rather than an alias, for two reasons.
The flow is more than one command,
and a `git-<name>` on the `PATH` wins over an alias that spells it —
verified against git 2.54 —
so an alias named `pr` beside the script would simply never run.

It is the shell one-liner this account has been pasting, with the GNU-only parts gone:

```
git push --set-upstream origin HEAD
gh pr create --fill
gh pr edit --title <first commit subject since the default branch> [--body <Closes lines>]
[gh pr merge --auto --squash]
```

* **The title** is corrected because `gh pr create --fill` reaches for the branch name
  once a branch has more than one commit.
  It becomes the subject of the first commit since the default branch — `upstream`'s where
  there is an `upstream` remote, `origin`'s otherwise, since a fork's `origin` is the fork.
* **The body** comes out of the branch name: split on dashes, drop the last field as the
  suffix that keeps two branches about the same issue apart, and turn every field that is
  a number into a `Closes #<n>.` line.
  `ghead -n -1 | gsed -r -n '...'` became one POSIX `awk`, so the script needs no GNU userland.
* **A branch name that yields no `Closes` line leaves the body alone**, rather than replacing
  what `--fill` wrote with an empty one. That is the one place I did not port the pasted
  command literally — say the word if overwriting was the intent.
* **Re-running updates** the pull request that is already there instead of failing,
  so an amended first commit is one `git pr` away from a matching title.

`--auto-merge` stays optional here, and `pra` is the alias that adds it:
merging a pull request is a thing done, not a setting offered.
`prm` warns and forwards to `pr`, the way `phuc` and `phuo` already do,
since the script opens against the default branch anyway.

## `gh-repo-setup` (#41)

The issue's four lines as one script.
Owner and name are read off `upstream`, or off `origin` where there is no `upstream`,
out of every spelling a remote URL comes in — SSH, `ssh://`, HTTPS, HTTPS with a credential,
with or without the `.git` suffix — and passed to `gh repo edit` spelled out,
which is what it refuses to do without.

All three options are set every time, `--enable-auto-merge` included, so the flag the issue
suggested is not there: these are settings a repository *offers* rather than performs,
and a fork that will never merge a pull request is no reason to leave one off.
`gh repo fork` stays a command you type, and the run after it sets the same three.

Both scripts are POSIX `/bin/sh`, usage to stderr and `exit 1`, in `rcm/bin/`, per the issue.

## Checks

`71-git-pr` and `72-gh-repo-setup`, both reading the commands off `--dry-run`:
no check reaches GitHub, and neither needs `gh` installed.
They pin the parts with real logic — first-commit title, the `Closes` derivation,
the trailing-field-is-a-suffix rule, remote preference, URL parsing —
plus the argument handling the issue asks for.

`71-git-pr` commits, and neither the throw-away home nor a CI runner has a git identity
to commit with, which is what the first Ubuntu run failed on;
it now exports the same four variables `27-bootstrap-private` does.
Verified by starving git of all config (`GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`),
which is what the runner looked like. The full suite passes.