### PR TITLE
feat(editor): Zed as the editor, with the widget that feeds it

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -18,7 +18,8 @@ and the same question brings both to the same leaf.
   directory: the dot rules, the tags, the private sidecar, the `PATH`,
   the home-grown layout it replaced
 * [`config/`](config/) — what the installed configuration does:
-  the inventory, zsh startup profiling, zsh completion
+  the inventory, zsh startup profiling, zsh completion,
+  the prompt marks, the editor
 * [`tools/`](tools/) — the scripts that land in `~/bin`,
   grouped by what they are for, each with its status
 * [`testing/`](testing/) — the throw-away home directory,

--- a/handbook/config/README.md
+++ b/handbook/config/README.md
@@ -10,3 +10,4 @@ and how anything gets there at all is
 * [`zsh-startup/`](zsh-startup/) — every interactive zsh times its own startup
 * [`completion/`](completion/) — zsh completion, audited daily instead of per shell
 * [`prompt-marks/`](prompt-marks/) — every prompt, command and exit status marked for the terminal
+* [`editor/`](editor/) — the editor every tool is handed, and the widget that hands it the command line

--- a/handbook/config/editor/README.md
+++ b/handbook/config/editor/README.md
@@ -1,0 +1,77 @@
+# The editor
+
+What `$EDITOR` and `$VISUAL` name,
+where the value is set and what it falls back to,
+and the zsh widget that hands the command line being typed
+to whatever they name.
+
+**Both variables carry the same value,
+and [`rcm/profile`](/rcm/profile) is where it is set:
+`zed --wait`, or `vim` on a machine without the Zed command line.**
+`~/.profile` is the file every login shell of this repository reaches —
+bash through `~/.bash_profile`, zsh through `~/.zprofile`,
+the chain [`layout/path/`](/handbook/layout/path/README.md) describes
+for the `PATH` — so the editor is chosen once
+and inherited by everything either shell goes on to start.
+`~/.zshrc` would reach interactive zsh alone,
+and an editor is asked for from far more places than that:
+a `git commit` in a script, a `crontab -e` over ssh,
+a bash that never became a zsh.
+
+`$VISUAL` is not a courtesy copy.
+git reads it before `$EDITOR` on any terminal that is not `dumb`,
+and so does zsh's `edit-command-line`,
+so a `$VISUAL` left standing is an `$EDITOR` nobody reads.
+That is also why the block in [`rcm/zshrc`](/rcm/zshrc)
+that hands the editor to the terminal it is running in —
+VS Code and Positron, each opening the file in the window
+the command was started from —
+sets the two together.
+
+**`--wait` is what makes Zed an editor here rather than a launcher.**
+`zed FILE` hands the path to the instance already running and returns
+immediately, and everything that asks for an editor reads the file back
+as soon as the command it started has exited:
+`git commit` would take the untouched template as the message,
+and the widget below would take back the line it sent.
+Both failures are silent, and neither leaves anything to notice later.
+A value of more than one word suits both:
+git runs the editor through the shell,
+and zsh's own function splits the variable before running it.
+
+**A machine without the Zed command line gets vim**,
+which is what a Linux box, a container or an ssh session ends up with
+unless Zed is installed on it.
+The guard is `command -v zed`, a builtin in both shells,
+so a login costs no process for asking
+(the standard the whole zsh startup is held to is
+[`config/zsh-startup/`](/handbook/config/zsh-startup/README.md)'s).
+It asks for that name only:
+Zed's Linux packages carry the command line themselves
+and some distributions name it `zeditor`,
+and a machine spelling it that way falls back to vim
+until something links the name `zed` onto the `PATH`.
+
+**On macOS the `zed` command comes from Zed itself.**
+The application installs `/usr/local/bin/zed` when the `cli: install`
+command is run from its command palette
+([Zed's CLI reference](https://zed.dev/docs/reference/cli)),
+and nothing in this repository installs, links or checks for it —
+an account that has never run that command is an account
+that gets the fallback.
+
+**`^X^E` opens the command line being typed in that editor.**
+[`rcm/zshrc`](/rcm/zshrc) autoloads zsh's own `edit-command-line`,
+registers it as a widget and binds it;
+the widget writes the line to a temporary file,
+runs the editor on it,
+and replaces the line with what the file holds when the editor exits —
+the same requirement as `git commit`'s, from the other end.
+`autoload` registers a name and reads nothing,
+so a shell that never presses the key never opens the file.
+
+**git is left to find the editor in the environment.**
+[`rcm/gitconfig`](/rcm/gitconfig) sets no `core.editor`:
+git's order is `$GIT_EDITOR`, then `core.editor`, then `$VISUAL`
+and `$EDITOR`, so setting it would only mean a second place to change
+the value and a second answer to `git var GIT_EDITOR`.

--- a/handbook/config/files/README.md
+++ b/handbook/config/files/README.md
@@ -8,7 +8,7 @@ The naming rules that turn `rcm/bashrc` into `~/.bashrc` are
 | File | Installed as | |
 | --- | --- | --- |
 | [`rcrc`](/rcm/rcrc) | `~/.rcrc` | drives the mapping itself |
-| [`profile`](/rcm/profile), [`zprofile`](/rcm/zprofile) | `~/.profile`, `~/.zprofile` | login shells of any kind: `~/bin` and `~/.local/bin` on the `PATH` ([`layout/path/`](/handbook/layout/path/README.md)) |
+| [`profile`](/rcm/profile), [`zprofile`](/rcm/zprofile) | `~/.profile`, `~/.zprofile` | login shells of any kind: `~/bin` and `~/.local/bin` on the `PATH` ([`layout/path/`](/handbook/layout/path/README.md)), and the [editor](/handbook/config/editor/README.md) every tool is handed |
 | [`bashrc`](/rcm/bashrc), [`bash_profile`](/rcm/bash_profile), [`bash_aliases`](/rcm/bash_aliases) | `~/.bashrc`, `~/.bash_profile`, `~/.bash_aliases` | interactive bash: prompt, history, aliases |
 | [`tag-macos/bash_aliases_os`](/rcm/tag-macos/bash_aliases_os), [`tag-linux/bash_aliases_os`](/rcm/tag-linux/bash_aliases_os) | `~/.bash_aliases_os` | the aliases, completions and bindings of one platform, sourced from `~/.bash_aliases` |
 | [`zshenv`](/rcm/zshenv), [`zshrc`](/rcm/zshrc) | `~/.zshenv`, `~/.zshrc` | zsh: the startup profiler for every shell, completion, history and [prompt marks](/handbook/config/prompt-marks/README.md) for the interactive ones |

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -104,6 +104,19 @@ and they run in name order:
 - `50-makefile`: the `Makefile` fallback agrees with the tasks
   it stands in for,
   and the targets it does not implement say so instead of pretending.
+- `55-editor`: `$EDITOR` and `$VISUAL` name a Zed told to wait
+  in a login shell of each of the three kinds,
+  git edits with the same value,
+  `^X^E` is bound in an interactive zsh,
+  and a `PATH` without Zed on it falls back to vim
+  ([`config/editor/`](/handbook/config/editor/README.md)).
+  The `--wait` is the half worth pinning:
+  an editor that returns before the file is written
+  discards the commit message and the command line without a word.
+  It brings its own home directory and installs into it,
+  because `~/.profile` carries the value
+  and the throw-away home has the one `/etc/skel` seeded;
+  and it stubs `zed`, which is on neither CI runner.
 - `60-zsh-startup`: a zsh startup complains about nothing,
   and `~/.zshrc` binds `mise` to the stub —
   the generated completion is *not* loaded at startup,

--- a/rcm/profile
+++ b/rcm/profile
@@ -40,6 +40,28 @@ if [ -d "$HOME/.local/bin" ]; then
     esac
 fi
 
+# The editor everything that asks for one gets: `git commit`, `crontab -e`,
+# and the zsh widget that opens the command line being typed.
+# One home for the value, read by bash and by zsh alike -- ~/.zprofile hands
+# this file to zsh at login -- which is why it is not in ~/.zshrc.
+#
+# --wait is what makes Zed an editor here rather than a launcher: `zed FILE`
+# hands the path to the running instance and returns at once, and each of the
+# three reads the file back as soon as the command it started has exited,
+# so the commit message written without it is the empty template.
+#
+# `command -v` is a builtin in both shells, so the guard costs no process;
+# vim is what a machine without the Zed command line falls back to.
+# Why the value lives here, and where the macOS `zed` comes from:
+# handbook/config/editor/README.md in the scriptlets repository.
+if command -v zed >/dev/null 2>&1; then
+    EDITOR="zed --wait"
+else
+    EDITOR=vim
+fi
+VISUAL=$EDITOR
+export EDITOR VISUAL
+
 # rig appends this line to every startup file it knows about,
 # and only ever checks that the line is there.
 # This is the one copy that runs;

--- a/rcm/zshrc
+++ b/rcm/zshrc
@@ -154,11 +154,19 @@ autoload -Uz bashcompinit && bashcompinit
 # ---------------------------------------------------------------------------
 # Editor and aliases
 # ---------------------------------------------------------------------------
+# The default is ~/.profile's, for every shell
+# (handbook/config/editor/README.md); a terminal that is an editor window
+# takes it over, so that a commit written there opens where it was started.
 if [[ $TERM_PROGRAM == vscode ]]; then
   case $__CFBundleIdentifier in
     com.microsoft.VSCode) export EDITOR="code --wait" ;;
     co.posit.positron)    export EDITOR="positron --wait" ;;
   esac
+
+  # $VISUAL follows $EDITOR rather than standing still: git and zsh's
+  # edit-command-line both read it first, so the value from ~/.profile would
+  # shadow the line above and open the editor this terminal is not.
+  export VISUAL=$EDITOR
 fi
 
 compdef g=git
@@ -198,6 +206,19 @@ if [[ -z ${precmd_functions[(r)_ghostty_deferred_init]} ]]; then
     PS1=$'%{\e]133;A\a%}'$PS1$'%{\e]133;B\a%}'
   fi
 fi
+
+# ---------------------------------------------------------------------------
+# ^X^E opens the command line being typed in the editor, and takes back
+# whatever the editor leaves behind
+# (handbook/config/editor/README.md in the scriptlets repository).
+#
+# `autoload` registers the name and reads nothing: the function is compiled on
+# the first press of the key and never in a shell that does not press it,
+# which is what keeps a widget off the startup budget.
+# ---------------------------------------------------------------------------
+autoload -Uz edit-command-line
+zle -N edit-command-line
+bindkey '^X^E' edit-command-line
 
 # Last line on purpose: the mark records when this file was *done*, and the gap
 # between it and the first prompt is everything the terminal does after the

--- a/tests/checks/55-editor.sh
+++ b/tests/checks/55-editor.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# The editor every tool that asks for one is handed, and the zsh widget that
+# hands it the command line
+# (handbook/config/editor/README.md).
+#
+# The name of the editor is the smaller half of the claim. What a check can
+# catch and a reading cannot is the `--wait`: `zed` without it gives the file
+# to the window already open and returns at once, so `git commit` reads back
+# the template it wrote and the widget reads back the line it sent -- silently,
+# both of them. So the value is compared whole rather than searched for a
+# `zed` in it.
+#
+# The check brings its own home directory, because the value is ~/.profile's
+# and the throw-away home the other checks read has Ubuntu's: /etc/skel seeds
+# one there and rcm leaves a file that already exists alone
+# (tests/checks/30-preexisting.sh is where that behaviour is checked).
+#
+# The Zed command line is on neither CI runner and may well be on a developer
+# machine, so both sides are arranged rather than waited for: a stub named
+# `zed` is what puts one on the `PATH`, and the fallback is checked with the
+# directory holding it taken away again -- except on a machine carrying a real
+# one, which no `PATH` of ours can hide.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+home=$(mktemp -d "${TMPDIR:-/tmp}/scriptlets-editor.XXXXXX")
+stub=$home/stub-bin
+mkdir -p "$stub"
+
+# Never started by anything here: every shell below is asked what $EDITOR is,
+# not to run it. Being found is all the guard in ~/.profile asks of it.
+cat >"$stub/zed" <<'STUB'
+#!/bin/sh
+echo "zed $*"
+STUB
+chmod +x "$stub/zed"
+
+(
+    HOME=$home
+    export HOME
+
+    assert_ok "mise run install succeeds" mise -C "$REPO" run install
+
+    # ~/.profile prepends to the PATH it inherits rather than building a new
+    # one, so a directory put in front here is still in front inside the login
+    # shell.
+    PATH="$stub:$PATH"
+    export PATH
+
+    # The three shells a fresh account may log in with, as in the PATH check:
+    # the value is set once, in ~/.profile, and bash and zsh have each their
+    # own way of arriving there.
+    for shell in sh bash zsh; do
+        if ! command -v "$shell" >/dev/null 2>&1; then
+            skip "$shell: not installed"
+            continue
+        fi
+
+        assert_equal "$shell: EDITOR is Zed, told to wait" \
+            "zed --wait" "$(login_output "$shell" 'printf %s "$EDITOR"')"
+
+        # Not a second spelling of the assertion above: git and zsh's
+        # edit-command-line both read $VISUAL first, so a $VISUAL left behind
+        # is a $EDITOR ignored.
+        assert_equal "$shell: VISUAL says the same" \
+            "zed --wait" "$(login_output "$shell" 'printf %s "$VISUAL"')"
+    done
+
+    # `core.editor` is unset on purpose (rcm/gitconfig): git falls back to the
+    # environment, and asking git itself is what shows the two ends meet.
+    # $GIT_EDITOR is dropped rather than trusted -- it outranks both variables,
+    # and the harness may well be running under a tool that exports it.
+    assert_equal "git edits with what the login shell set" \
+        "zed --wait" "$(login_output sh 'env -u GIT_EDITOR git var GIT_EDITOR')"
+
+    if command -v zsh >/dev/null 2>&1; then
+        # An interactive shell rather than a login one: the binding is
+        # ~/.zshrc's. $ZDOTDIR is dropped so that a suite run from a terminal
+        # that sets it still reads the file installed above.
+        assert_equal "^X^E opens the command line in the editor" \
+            '"^X^E" edit-command-line' \
+            "$(env -u ZDOTDIR zsh -ic 'bindkey "^X^E"' 2>/dev/null | tail -n 1)"
+    fi
+
+    # --- the machine without Zed --------------------------------------------
+
+    PATH=${PATH#"$stub:"}
+    export PATH
+
+    if command -v zed >/dev/null 2>&1; then
+        skip "the fallback: this machine has a Zed command line of its own"
+    else
+        assert_equal "without Zed, EDITOR is vim" \
+            "vim" "$(login_output sh 'printf %s "$EDITOR"')"
+        assert_equal "without Zed, VISUAL is vim" \
+            "vim" "$(login_output sh 'printf %s "$VISUAL"')"
+    fi
+)
+
+rm -rf "$home"


### PR DESCRIPTION
`$EDITOR` and `$VISUAL` are set in `rcm/profile` — the one file every login shell of this repository reaches, bash through `~/.bash_profile` and zsh through `~/.zprofile`. `~/.zshrc` would reach interactive zsh alone, and an editor is asked for from far more places than that: a `git commit` in a script, a `crontab -e` over ssh, a bash that never became a zsh.

`--wait` is load-bearing rather than decorative. `zed FILE` hands the path to the instance already running and returns at once, while `git commit` and zsh's `edit-command-line` both read the file back as soon as the command they started has exited — so without it the commit message is the untouched template and the edited command line is the line that was sent, both silently.

The guard is `command -v zed`, a builtin in both shells, so a login costs no process for asking; a machine without the Zed command line — a Linux box, a container, an ssh session — gets vim.

`$VISUAL` is set alongside `$EDITOR` everywhere, including in the VS Code and Positron block in `rcm/zshrc` that hands the editor to the terminal it runs in. Both git (on any terminal that is not `dumb`) and `edit-command-line` read `$VISUAL` first, so a `$VISUAL` left standing is an `$EDITOR` nobody reads. That block previously set `$EDITOR` alone, which the new `$VISUAL` from `~/.profile` would have shadowed.

`^X^E` is bound in `rcm/zshrc`, next to the OSC 133 block: `autoload -Uz edit-command-line`, `zle -N`, `bindkey`. `autoload` registers a name and reads nothing, so a shell that never presses the key never opens the file.

`core.editor` stays unset in `rcm/gitconfig`, so git keeps finding the value in the environment and there is one home for it.

`tests/checks/55-editor.sh` pins the `--wait` rather than the name: `$EDITOR` and `$VISUAL` in a login shell of each of the three kinds, `git var GIT_EDITOR` agreeing with them, `^X^E` bound in an interactive zsh, and the fallback to vim with the stub `zed` off the `PATH`. It brings its own home directory and installs into it, because `~/.profile` carries the value and the throw-away home the other checks read has the one `/etc/skel` seeded.

`handbook/config/editor/README.md` is the leaf, linked from `config/`, the file inventory and the root sketch. It covers why `--wait`, why `profile` rather than `zshrc`, what a host without Zed gets — including that some Linux packages name the binary `zeditor`, which the guard will not find — and that the macOS `zed` comes from Zed's own `cli: install` command.

`tests/run` passes in full. The new check was also run against a `~/.profile` with the `--wait` dropped and a `~/.zshrc` with the binding commented out, and fails in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChZZWbVu2p3FUyo82th5bj