### PR TITLE
feat(git): `dz` opens the current diff in Zed

### DIFF
--- a/handbook/install/prerequisites/README.md
+++ b/handbook/install/prerequisites/README.md
@@ -156,4 +156,4 @@ Homebrew's `azure-cli` installs `az`, which is a different one.
 
 *To deepen: run the `pacman` lines on an Arch machine;
 collect what the shipped configuration reaches for —
-`delta`, `daff`, `git-lfs`, `tig`, `diffuse`.*
+`delta`, `daff`, `git-lfs`, `tig`, `diffuse`, `zed`.*

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -89,6 +89,17 @@
 	dcw = diff --cached --word-diff
 	dm = !sh -c 'diffuse -m "$@" &' -
 	dmh = !sh -c 'diffuse -c HEAD &' -
+	# The same diff in Zed: --dir-diff hands the tool both trees in one
+	# call, and `zed --diff` recurses into a pair of directories and
+	# shows every changed file in a single multi-diff view.
+	# --no-symlinks is what makes that work: the right-hand tree is
+	# symlinks into the working tree otherwise, and the walk behind
+	# --diff steps over those, leaving every file looking deleted.
+	# This one waits where dm backgrounds -- git takes the trees down
+	# when the tool exits, and copies whatever was edited on the right
+	# back into the working tree first.
+	# Arguments are git diff's: `git dz HEAD^!` is dmh's view.
+	dz = difftool --dir-diff --no-symlinks --tool=zed
 	f = fetch --prune
 	fa = fetch --all --prune -j 32
 	lsf = "!f() { if [ ${GIT_PREFIX} != ${PWD} ]; then cd ${GIT_PREFIX}; fi; git ls-files $@ -z | xargs -0 -n1 '-I{}' -- git log -1 --format=%ai\\ {} '{}'; }; f"

--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -21,6 +21,8 @@
 	cmd = "~/bin/imgdiff-bg \"$LOCAL\" \"$REMOTE\""
 [difftool "diffpdf"]
 	cmd = "diffpdf \"$LOCAL\" \"$REMOTE\""
+[difftool "zed"]
+	cmd = "zed --wait --diff \"$LOCAL\" \"$REMOTE\""
 [merge "daff-csv"]
 	name = daff tabular csv merge
 	driver = daff merge --output %A %O %A %B


### PR DESCRIPTION
A sibling to the Diffuse aliases in `rcm/gitaliases`. `zed --diff` recurses into a pair of directories and shows every changed file as one multi-diff, which is exactly what `git difftool --dir-diff` has to hand:

    dz = difftool --dir-diff --no-symlinks --tool=zed

`--no-symlinks` is required rather than tidy. The right-hand tree is symlinks into the working tree by default, and Zed's walk over the directory counts only regular files, so every changed file would pair with an empty stub and read as deleted. With copies on both sides the multi-diff is right, and git copies whatever was edited on the right back into the working tree when the tool exits — which is also why the alias waits where `dm` backgrounds.

The tool is named in `rcm/gitconfig`, beside `imgdiff` and `diffpdf`, rather than passed as `--extcmd`: in `--dir-diff` mode git hands the extcmd string to `exec` unsplit, so `-x 'zed --wait --diff'` fails with `cannot run zed --wait --diff`, while a configured `cmd` goes through the shell.

Being a plain alias, it takes `git diff`'s arguments: `git dz HEAD^!` is `dmh`'s view, `git dz --cached` the staged one.

`zed` joins the list of tools the shipped configuration reaches for in `handbook/install/prerequisites/README.md`.

Each of the three behaviours above was checked against a stub `zed` in a throw-away repository rather than assumed: the two directories arrive as one call, the default symlinks are what Zed's walk skips, and an edit made on the right lands in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChZZWbVu2p3FUyo82th5bj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChZZWbVu2p3FUyo82th5bj)_