### PR TITLE
feat: `git ff` fast-forwards the branches a worktree holds too

### DIFF
--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -164,6 +164,14 @@ and they run in name order:
   and the three options it sets.
   Neither check reaches GitHub, and neither needs `gh` installed:
   `--dry-run` puts the commands on stdout instead of running them.
+- `73-git-ff`: `git ff` moves a branch nothing has checked out
+  and one a linked worktree holds — the second is the case
+  `git push .` cannot reach, and the reason the script exists —
+  while a worktree with uncommitted changes and a diverged branch
+  are left as they were.
+  Its remote is a second repository below the throw-away home
+  and the clone is made from that path,
+  so the fetches and the push stay on this disk.
 - `75-h`: `h` runs the command in every repository below the current
   directory, and each line of output says which one it came from.
   Both halves matter:

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -65,6 +65,26 @@ non-repository case under review below.
 
 ### Git, one repository at a time
 
+**`git-ff`** — fast-forward every branch that is behind the branch it
+tracks, in one pass, fetching nothing:
+`git fa` first, `git ff` second.
+Two mechanisms, because neither reaches both halves.
+A branch nothing has checked out is moved by pushing into the repository
+itself, `git push . <upstream>:<branch>`,
+which refuses anything that is not a fast-forward and so cannot go wrong;
+a branch a worktree holds cannot be pushed to at all —
+git declines to move the branch of any worktree, the current one and a
+linked one alike, since the index and the working tree would stop
+agreeing with it —
+and is fast-forwarded from inside that worktree with `merge --ff-only`.
+A worktree with uncommitted changes is skipped and named,
+because a branch left behind in silence reads exactly like one that was
+already up to date;
+a branch that has diverged is not fast-forwardable and is left alone.
+`-n` / `--dry-run` says what would happen.
+`git ff` is the whole spelling — the old `fft` warns and forwards —
+and the branches of *other* repositories are `s plf`'s, further up.
+
 **`git-pr`** — open the pull request for the current branch, or update
 the one that is already there: push the branch, let `gh` fill the body
 from its commits, then correct the title to the first commit's subject

--- a/rcm/bin/git-ff
+++ b/rcm/bin/git-ff
@@ -1,0 +1,125 @@
+#!/bin/sh
+# Fast-forward every branch that is behind the remote branch it tracks, the
+# ones checked out in a worktree included.
+#
+# Two mechanisms, because one cannot do both halves. A branch nothing has
+# checked out is moved by pushing into this repository -- `git push .
+# <upstream>:<branch>` -- which refuses anything that is not a fast-forward and
+# so is safe by construction. A branch that is checked out cannot be pushed to
+# at all: git refuses to update the branch of any worktree, the current one and
+# a linked one alike, because the index and the working tree would no longer
+# agree with it. Those are fast-forwarded from inside their own worktree
+# instead, with `git merge --ff-only`, and only where nothing is uncommitted
+# there -- a dirty worktree is left alone and named.
+set -eu
+
+dry_run=0
+
+usage() {
+    cat <<'EOF'
+Usage: git ff [-n|--dry-run]
+
+Fast-forward every branch that is behind its upstream:
+
+  a branch nothing has checked out  ->  git push . <upstream>:<branch>
+  a branch a worktree holds         ->  git merge --ff-only, in that worktree
+
+Branches that are ahead, or that have diverged, are not fast-forwardable
+and are left alone; so is a worktree with uncommitted changes, which is
+named rather than passed over in silence. Nothing is fetched -- run
+`git fa` first, and this second.
+
+Options:
+  -n, --dry-run  say what would happen, change nothing
+  -h, --help     show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -n | --dry-run) dry_run=1 ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        printf 'git-ff: unknown option: %s\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Says "fatal: not a git repository" in git's own words, and stops.
+git rev-parse --git-dir >/dev/null
+
+# Which worktree holds which branch, as `branch<tab>path` lines. The main
+# worktree is in there too: its branch is as unpushable as a linked one's.
+held=$(git worktree list --porcelain |
+    awk '
+        /^worktree /  { path = substr($0, 10) }
+        /^branch /    { print substr($0, 19) "\t" path }
+    ')
+
+# path_of BRANCH -- the worktree holding it, or nothing.
+path_of() {
+    printf '%s\n' "$held" |
+        awk -F'\t' -v branch="$1" '$1 == branch { print $2; exit }'
+}
+
+# say WORD MESSAGE -- one line per branch, so a run reads as a list.
+say() {
+    printf '%-10s %s\n' "$1" "$2"
+}
+
+status=0
+
+# The branches are read from a file rather than from a pipe, because a `while`
+# on the right of a `|` runs in a subshell, and the exit status this sets there
+# would be thrown away with it.
+branches=$(mktemp "${TMPDIR:-/tmp}/git-ff.XXXXXX")
+trap 'rm -f "$branches"' EXIT HUP INT TERM
+
+# `%(upstream:track,nobracket)` says "behind 2" for the branches this is for,
+# "ahead 1" or "ahead 1, behind 2" for the ones it is not, and nothing at all
+# for a branch with no upstream or one that is level.
+git for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)' \
+    refs/heads >"$branches"
+
+while IFS="$(printf '\t')" read -r branch upstream track; do
+    case $track in
+    behind\ *) ;;
+    *) continue ;;
+    esac
+
+    worktree=$(path_of "$branch")
+
+    if [ -z "$worktree" ]; then
+        if [ "$dry_run" -eq 1 ]; then
+            say "would push" "$branch <- $upstream ($track)"
+        elif git push --quiet . "$upstream:$branch"; then
+            say "pushed" "$branch <- $upstream ($track)"
+        else
+            say "failed" "$branch <- $upstream"
+            status=1
+        fi
+        continue
+    fi
+
+    if [ -n "$(git -C "$worktree" status --porcelain)" ]; then
+        say "dirty" "$branch in $worktree ($track)"
+        continue
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        say "would merge" "$branch in $worktree ($track)"
+    elif git -C "$worktree" merge --quiet --ff-only "$upstream" >/dev/null; then
+        say "merged" "$branch in $worktree ($track)"
+    else
+        say "failed" "$branch in $worktree"
+        status=1
+    fi
+done <"$branches"
+
+exit $status

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -60,7 +60,9 @@
 	# b -d
 	# b -D
 	# ---
-	fft = "!sh -c 'git bvv | $(which gsed || which sed)  -r -n \"/^ +([^ ]+) +[^ ]+ [[]([^:]+): behind.*$/ {s//git push . \\2:\\1/ p}\" | sh -x' -"
+	# The fast-forward is `git ff` in ~/bin now, and reaches the branches a
+	# worktree holds as well; the old spelling warns, then forwards.
+	fft = "!echo 'warning: fft is now ff' >&2; git ff"
 	# === Conflict resolution
 	ma = merge --abort
 	# ---

--- a/tests/checks/73-git-ff.sh
+++ b/tests/checks/73-git-ff.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# `git ff` fast-forwards what can be fast-forwarded, by whichever of its two
+# mechanisms the branch needs, and leaves the rest alone and named.
+#
+# The four states a branch can be in are built below and checked in one run:
+# behind and checked out nowhere, behind and held by a linked worktree, held by
+# a worktree with uncommitted changes, and diverged. The one that matters most
+# is the second: `git push .` cannot touch it, which is the reason the script
+# exists.
+#
+# Nothing here reaches the network. The "remote" is a second repository below
+# $HOME and the clone is made from its path, so `git clone`, `git fetch` and
+# the push into the repository itself all stay on this disk.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+# The throw-away home has no git identity, and neither does a CI runner: the
+# repository's ~/.gitconfig only carries one for an account with a tag.
+GIT_AUTHOR_NAME=check
+GIT_AUTHOR_EMAIL=check@example
+GIT_COMMITTER_NAME=check
+GIT_COMMITTER_EMAIL=check@example
+export GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+
+work=$HOME/git-ff-check
+rm -rf "$work"
+mkdir -p "$work"
+
+remote=$work/remote
+clone=$work/clone
+
+# --- a repository in every state the script distinguishes --------------------
+
+git init -q -b main "$remote"
+printf 'base\n' >"$remote/file"
+git -C "$remote" add file
+git -C "$remote" commit -q -m base
+
+for branch in idle held dirty diverged; do
+    git -C "$remote" switch -q -c "$branch" main
+    printf '%s\n' "$branch" >>"$remote/file"
+    git -C "$remote" commit -q -am "$branch"
+done
+git -C "$remote" switch -q main
+
+git clone -q "$remote" "$clone"
+
+# Each branch one commit behind the remote, and then the remote one ahead
+# again, so that every one of them is behind by two.
+for branch in idle held dirty diverged; do
+    git -C "$clone" switch -q -c "$branch" "origin/$branch"
+    git -C "$clone" reset -q --hard HEAD~1
+done
+git -C "$clone" switch -q main
+
+for branch in idle held dirty diverged; do
+    git -C "$remote" switch -q "$branch"
+    printf 'more\n' >>"$remote/file"
+    git -C "$remote" commit -q -am "$branch again"
+done
+git -C "$remote" switch -q main
+git -C "$clone" fetch -q --all
+
+git -C "$clone" worktree add -q "$work/held" held
+git -C "$clone" worktree add -q "$work/dirty" dirty
+printf 'uncommitted\n' >"$work/dirty/scratch"
+
+git -C "$clone" switch -q diverged
+printf 'local\n' >>"$clone/file"
+git -C "$clone" commit -q -am "a commit the remote does not have"
+git -C "$clone" switch -q main
+
+# tracking BRANCH -- what `git branch -vv` says about it, upstream and all.
+tracking() {
+    git -C "$clone" for-each-ref --format='%(upstream:track,nobracket)' \
+        "refs/heads/$1"
+}
+
+run() {
+    output=$(git -C "$clone" ff "$@" 2>&1)
+    status=$?
+}
+
+# --- the dry run says what it would do, and does none of it ------------------
+
+run --dry-run
+assert_equal "--dry-run succeeds" "0" "$status"
+assert_match "it would push the branch nothing has checked out" \
+    "*would push idle*" "$output"
+assert_match "it would merge the branch a worktree holds" \
+    "*would merge held*" "$output"
+assert_equal "and it changed nothing" "behind 2" "$(tracking idle)"
+
+# --- the run itself ----------------------------------------------------------
+
+run
+assert_equal "the run succeeds" "0" "$status"
+
+assert_equal "a branch checked out nowhere reaches its upstream" "" \
+    "$(tracking idle)"
+assert_equal "so does one a linked worktree holds" "" "$(tracking held)"
+assert_equal "and that worktree is at the new commit" \
+    "$(git -C "$clone" rev-parse held)" "$(git -C "$work/held" rev-parse HEAD)"
+assert_equal "with nothing left uncommitted in it" "" \
+    "$(git -C "$work/held" status --porcelain)"
+
+# The two it must not touch, and the reason it says so out loud: a branch left
+# behind without a word is indistinguishable from one that was up to date.
+assert_equal "a worktree with uncommitted changes is left behind" "behind 2" \
+    "$(tracking dirty)"
+assert_match "and named" "*dirty*$work/dirty*" "$output"
+assert_equal "the file it had uncommitted is still there" "uncommitted" \
+    "$(cat "$work/dirty/scratch")"
+
+assert_equal "a diverged branch is left alone" "ahead 1, behind 2" \
+    "$(tracking diverged)"
+assert_equal "and is not mentioned" "" \
+    "$(printf '%s\n' "$output" | grep diverged || true)"
+
+# --- a second run --------------------------------------------------------
+
+run
+assert_equal "a second run succeeds" "0" "$status"
+assert_equal "and fast-forwards nothing more" "" \
+    "$(printf '%s\n' "$output" | grep -E 'pushed|merged' || true)"
+
+# --- where it refuses -------------------------------------------------------
+
+run --nonsense
+assert_equal "an unknown option fails" "1" "$status"
+assert_match "an unknown option prints the usage" "*Usage:*" "$output"


### PR DESCRIPTION
`fft` fast-forwarded every branch that was behind by pushing into the repository,
and skipped every branch a worktree had checked out — not by decision but by accident.
`git branch -vv` marks those with a `+` and prints the worktree path mid-line:

```
+ feature 3786939 (/tmp/wtlab/git/repo-feature) [origin/feature: behind 1] f1
* main    5413cf0 [origin/main] m2
  other   5413cf0 [origin/other: behind 1] m2
```

Neither the `+` nor the `(path)` survives `fft`'s regular expression, which anchors on
a run of leading spaces. Verified: with both branches behind by one, `git fft`
fast-forwarded `other` and left `feature` untouched and unmentioned.

Skipping was *right* — `git push . <upstream>:<branch>` is refused for a branch any
worktree holds, the current one and a linked one alike ("refusing to update checked out
branch"). Saying nothing was not, and with a worktree per pull request most branches
are now in exactly that state.

## What `git ff` does

Two mechanisms, because neither reaches both halves:

* **checked out nowhere** → `git push . <upstream>:<branch>`, unchanged, and safe by
  construction since it refuses anything that is not a fast-forward
* **held by a worktree** → `git merge --ff-only <upstream>` from inside that worktree

and two states it refuses to touch, out loud:

* **a worktree with uncommitted changes** is skipped and named — a branch left behind in
  silence reads exactly like one that was already up to date
* **a diverged branch** is not fast-forwardable, so it is left alone

It reads `git for-each-ref --format='...%(upstream:track,nobracket)'` rather than another
alias's output, so the `+` that hid a worktree branch cannot hide one again. A script
rather than an alias because two mechanisms and a cleanliness test are more than an alias
should carry — and `fft` warns and forwards to it, as `sq` and `prm` do.

Nothing is fetched: `git fa` first, `git ff` second.

```
$ git ff
dirty      dirty in /tmp/fflab/repo-dirty (behind 2)
merged     held in /tmp/fflab/repo-held (behind 2)
pushed     idle <- origin/idle (behind 2)
```

## Check

`73-git-ff` builds all four states — behind and checked out nowhere, behind and held by a
linked worktree, held by a dirty worktree, diverged — and runs both the dry run and the
real one against them, then a second run to pin idempotence. It asserts the held
worktree's own `HEAD` moved and stayed clean, and that the dirty one kept its uncommitted
file.

The remote is a second repository below the throw-away home with the clone made from its
path, so nothing reaches the network, and the identity is exported the way
`27-bootstrap-private` does it. Full suite passes.

## Note on #62

That PR's trie is generated from `rcm/gitaliases`, and this changes `fft`. Whichever
merges second needs one `tests/git-aliases-trie` run — the `07-git-aliases` check says so
rather than letting the page drift, which is what it is for. I can do that as soon as the
order is known.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jmkJNHxMjwviBkqT1y2pv)_