### PR TITLE
feat(git): `dzm` and `dt`, and the alias prose moves to the handbook

### DIFF
--- a/handbook/config/git-aliases/README.md
+++ b/handbook/config/git-aliases/README.md
@@ -14,9 +14,19 @@ Which file lands where is
 A command that is typed daily takes a letter, its variants take a second,
 and a variant of a variant takes a third:
 `b` is `branch`, `bv` adds `-v`, `bvv` adds the second one.
-The push family says it in the file itself —
-the second letter picks the variant, an optional third picks the remote —
-and every other family reads the same way.
+The push family carries it furthest, and is worth learning as a scheme:
+`p` and then the variant — `h` plain, `f` for `--force-with-lease`,
+`t` for `--follow-tags`, `u` for `--set-upstream` —
+and then, where a third letter follows, the remote the current branch
+goes to: `c` for cynkra, `o` for origin, `u` for upstream,
+`k` for krlmlr where an account has one.
+`puo` is therefore `push --set-upstream origin HEAD`, read left to right.
+
+**A name takes git's own abbreviation where git has one.**
+`wt` is `worktree` because git spells the concept as two words itself,
+in `--work-tree` and `GIT_WORK_TREE`,
+so the two letters are the initials of the thing
+rather than a squeeze of one word.
 
 **A name that borrows an occupied prefix is not a variant of it.**
 `conflicts` begins with the letters of `checkout` and is a `diff`;
@@ -30,9 +40,16 @@ out of the family whose prefix it borrowed
 and gives it a group of its own.
 
 **A renamed spelling warns and forwards rather than vanishing.**
-`sq`, `phuc`, `phuo` and `prm` are the names their replacements used to have:
+`sq`, `fft`, `phuc`, `phuo` and `prm` are the names their replacements used
+to have:
 each prints one line to stderr and runs the new one,
 so fingers that learned the old spelling are corrected rather than stopped.
+`qs` took `sq`'s work because a squash is a `reset --soft` that ends in a
+commit, and belongs to the reset family rather than under `status`;
+`ff` took `fft`'s because the fast-forward became a script that reaches
+the branches a worktree holds ([`tools/`](/handbook/tools/README.md));
+`pr` took `prm`'s because the script it stands for opens against the
+default branch already.
 
 **A destructive variant keeps its long spelling.**
 `q --hard`, `b -d`, `b -D`, `clean` and `rm` appear in the file as comments
@@ -56,6 +73,63 @@ A plain expansion can lose it too:
 completion walks the expansion a word at a time,
 so a `-c` whose value carries a space — `dt`'s does, to keep its colour —
 leaves it holding the tail of that value rather than the command.
+
+## What the longer expansions do
+
+Most expansions are their own explanation.
+These are the ones that are not, and the file points here for them.
+
+**`dz` opens the whole diff in Zed, and takes edits back.**
+`--dir-diff` hands the tool both trees in one call rather than a pair of
+files at a time, and `zed --diff` recurses into two directories and shows
+every changed file in a single multi-diff view.
+`--no-symlinks` is what makes that work:
+the right-hand tree is symlinks into the working tree otherwise,
+and the walk behind `--diff` steps over those,
+leaving every file looking deleted.
+It waits where `dm` backgrounds,
+because git takes the trees down when the tool exits —
+and copies whatever was edited on the right back into the working tree
+first.
+Its arguments are `git diff`'s, so `git dz HEAD^!` is `dmh`'s view.
+
+**`dzm` is the same against the branch this one grew out of.**
+It takes the merge base rather than `main...`,
+and that is the whole of it:
+git copies edits back only from the side that *is* the working tree,
+so naming two sides — which `main...` does, expanding to `main...HEAD` —
+makes both of them temporary copies and discards what was typed.
+One side named leaves the working tree as the other,
+and the merge base puts the fork point opposite it,
+which is what `main...` was reaching for.
+Uncommitted work is in the view as well, which is the point.
+The branch is the remote's own default,
+read from `refs/remotes/upstream/HEAD` and then `refs/remotes/origin/HEAD`
+— `git remote set-head origin --auto` is what writes those down —
+with `main` where neither says, and an argument overriding all of it.
+
+**`dt` diffs with difftastic**, which compares syntax trees rather than
+lines, and so tells a brace that moved from a line that changed.
+It sets `diff.external` for the one invocation rather than as a setting,
+so `git diff` stays what it was.
+`--color always` is not decoration:
+git hands an external diff to the pager,
+and a difft that sees a pipe rather than a terminal turns its colour off,
+while the `less -FRX` in [`rcm/gitconfig`](/rcm/gitconfig) passes the
+escapes through.
+That space inside the value is what costs the alias its completion,
+above.
+Where `difft` is not installed the alias says so and stops
+([`install/prerequisites/`](/handbook/install/prerequisites/README.md)).
+
+**`wtb` puts a worktree beside the repository it belongs to**, named for
+both: `~/git/repo` and `branch-name` make `~/git/repo-branch-name`.
+The name comes from the main worktree rather than the current one,
+so a run from inside a linked worktree is a sibling rather than a nest,
+and a slash in the branch name folds to a dash for the same reason.
+A branch that already exists, here or on exactly one remote, is checked
+out — git's own guessing sets the tracking branch up —
+and a name that is neither becomes a new branch.
 
 ## The trie
 

--- a/handbook/config/git-aliases/README.md
+++ b/handbook/config/git-aliases/README.md
@@ -52,6 +52,10 @@ Git's completion expands an alias to its first command word,
 so `git wt <TAB>` offers the `worktree` subcommands;
 an alias that begins with `!` gets no completion at all,
 and is marked as such in the trie so the cost is visible.
+A plain expansion can lose it too:
+completion walks the expansion a word at a time,
+so a `-c` whose value carries a space — `dt`'s does, to keep its colour —
+leaves it holding the tail of that value rather than the command.
 
 ## The trie
 
@@ -110,9 +114,11 @@ d * diff
 ├─c * diff --cached
 │  └─w * diff --cached --word-diff
 ├─d ! sh -c 'git diff | delta --max-line-length 2048 --navigate'
+├─t * -c diff.external='difft --color always' diff
 ├─u * diff @{u}
 ├─w * diff --word-diff
 └─z * difftool --dir-diff --no-symlinks --tool=zed
+   └─m ! f() { b=${1:-$(git symbolic-ref --short refs/remotes/upstrea…
 
 echo ! bash -c 'echo "${@: 0}"'
 

--- a/handbook/install/prerequisites/README.md
+++ b/handbook/install/prerequisites/README.md
@@ -156,6 +156,13 @@ while `compare` and `montage` are unaffected.
 **The Azure scripts drive an `azure` command** no manager here carries;
 Homebrew's `azure-cli` installs `az`, which is a different one.
 
+**`difft` is what `git dt` reaches for**, and Ubuntu 24.04 does not carry
+it: Homebrew has it as `difftastic`, and elsewhere it is
+`cargo install difftastic` or the binary from its releases.
+Where it is missing the alias says so and stops —
+`difft: not found`, then `fatal: external diff died` —
+and nothing else here wants it.
+
 *To deepen: run the `pacman` lines on an Arch machine;
 collect what the shipped configuration reaches for —
-`delta`, `daff`, `git-lfs`, `tig`, `diffuse`, `zed`.*
+`delta`, `daff`, `git-lfs`, `tig`, `diffuse`, `zed`, `difft`.*

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -1,3 +1,5 @@
+# Why a name is the name it is, what the longer expansions do, and the trie
+# they all make: handbook/config/git-aliases/README.md.
 [alias]
 	echo = "!bash -c 'echo \"${@: 0}\"'"
 	# === Basic commands
@@ -60,8 +62,6 @@
 	# b -d
 	# b -D
 	# ---
-	# The fast-forward is `git ff` in ~/bin now, and reaches the branches a
-	# worktree holds as well; the old spelling warns, then forwards.
 	fft = "!echo 'warning: fft is now ff' >&2; git ff"
 	# === Conflict resolution
 	ma = merge --abort
@@ -91,48 +91,14 @@
 	dcw = diff --cached --word-diff
 	dm = !sh -c 'diffuse -m "$@" &' -
 	dmh = !sh -c 'diffuse -c HEAD &' -
-	# The same diff in Zed: --dir-diff hands the tool both trees in one
-	# call, and `zed --diff` recurses into a pair of directories and
-	# shows every changed file in a single multi-diff view.
-	# --no-symlinks is what makes that work: the right-hand tree is
-	# symlinks into the working tree otherwise, and the walk behind
-	# --diff steps over those, leaving every file looking deleted.
-	# This one waits where dm backgrounds -- git takes the trees down
-	# when the tool exits, and copies whatever was edited on the right
-	# back into the working tree first.
-	# Arguments are git diff's: `git dz HEAD^!` is dmh's view.
 	dz = difftool --dir-diff --no-symlinks --tool=zed
-	# The same again, against the branch this one grew out of.
-	# The merge base, and not `main...`: naming two sides makes both of
-	# them temporary copies, and whatever was edited on the right is
-	# thrown away when the tool exits. One side named leaves the working
-	# tree as the other, and that is the side written back -- so
-	# uncommitted work is in the view as well, which is the point.
-	# The branch is the remote's own idea of its default, upstream before
-	# origin; `git remote set-head origin --auto` is what writes that
-	# down, and main stands in where neither says. Name one to override.
 	dzm = "!f() { b=${1:-$(git symbolic-ref --short refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo main)}; git dz $(git merge-base $b HEAD); }; f"
-	# Difftastic compares syntax trees rather than lines, which is what
-	# tells a brace that moved from a line that changed.
-	# --color always because git hands an external diff to the pager, and
-	# a difft that sees a pipe rather than a terminal turns its colour
-	# off; the `less -FRX` in gitconfig passes the escapes through.
-	# An option and then a command, so `dt` takes git diff's arguments.
-	# It is also where completion stops: git's completion reads an alias
-	# word by word to find the command it stands for, and the space inside
-	# the quoted value leaves it holding `always'` -- the price of the
-	# colour, since the value has to be one word to survive that walk.
 	dt = -c diff.external='difft --color always' diff
 	f = fetch --prune
 	fa = fetch --all --prune -j 32
 	lsf = "!f() { if [ ${GIT_PREFIX} != ${PWD} ]; then cd ${GIT_PREFIX}; fi; git ls-files $@ -z | xargs -0 -n1 '-I{}' -- git log -1 --format=%ai\\ {} '{}'; }; f"
 	mf = merge --ff
 	mu = merge-update
-	# Push: the second letter picks the variant,
-	# an optional third letter picks the remote
-	# and pushes the current branch.
-	# Variants: h plain, f --force-with-lease, t --follow-tags, u --set-upstream.
-	# Remotes: c cynkra, o origin, u upstream; k krlmlr, per user.
 	ph = push
 	pf = push --force-with-lease
 	pt = push --follow-tags
@@ -146,7 +112,6 @@
 	puo = push --set-upstream origin HEAD
 	puu = push --set-upstream upstream HEAD
 	# ---
-	# The old spellings warn, then forward.
 	phuc = "!echo 'warning: phuc is now puc' >&2; git puc"
 	phuo = "!echo 'warning: phuo is now puo' >&2; git puo"
 	pl = pull
@@ -156,14 +121,8 @@
 	qh = reset HEAD
 	sp = status --porcelain
 	# https://stackoverflow.com/a/5201642/946850
-	# The squash belongs to the reset family: the letters are qs, and the
-	# old spelling warns, then forwards.
 	qs = "!sh -c 'git reset --soft ${1:-main} && git commit --edit -m \"$(git log --format=%B --reverse HEAD..HEAD@{1})\"' -"
 	sq = "!echo 'warning: sq is now qs' >&2; git qs"
-	# Pull requests: `git pr` is the script in ~/bin, and needs no alias --
-	# a git-<name> on the PATH wins over an alias that spells it, so one
-	# here would never run. `pra` adds the auto-merge, and `prm` warns,
-	# then forwards: the script opens against the default branch already.
 	pra = pr --auto-merge
 	prm = "!echo 'warning: prm is now pr' >&2; git pr"
 	# ---
@@ -173,20 +132,10 @@
 	std = stash drop
 	stl = stash list
 	# ---
-	# Worktree: git spells the concept as two words itself,
-	# in --work-tree and GIT_WORK_TREE, and they give the two letters.
-	# w is switch, and git matches an alias name in full, never by
-	# prefix, so the two never meet.
 	wt = worktree
 	wta = worktree add
 	wtl = worktree list
 	wtm = worktree move
 	wtp = worktree prune
 	wtr = worktree remove
-	# wtb <branch> puts a worktree beside the repository it belongs to,
-	# named for both: ~/git/repo and branch-name make
-	# ~/git/repo-branch-name, and a slash in the branch name folds to a
-	# dash, so the sibling stays one directory rather than a nest.
-	# A branch that exists, here or on a remote, is checked out;
-	# a name that is neither becomes a new branch.
 	wtb = "!f() { r=$(git worktree list --porcelain | sed -n '1s/^worktree //p'); d=$r-$(printf %s $1 | tr / -); if git show-ref --verify --quiet refs/heads/$1 || test -n \"$(git for-each-ref --count=1 'refs/remotes/*/'$1)\"; then git worktree add \"$d\" $1; else git worktree add -b $1 \"$d\"; fi; }; f"

--- a/rcm/gitaliases
+++ b/rcm/gitaliases
@@ -102,6 +102,27 @@
 	# back into the working tree first.
 	# Arguments are git diff's: `git dz HEAD^!` is dmh's view.
 	dz = difftool --dir-diff --no-symlinks --tool=zed
+	# The same again, against the branch this one grew out of.
+	# The merge base, and not `main...`: naming two sides makes both of
+	# them temporary copies, and whatever was edited on the right is
+	# thrown away when the tool exits. One side named leaves the working
+	# tree as the other, and that is the side written back -- so
+	# uncommitted work is in the view as well, which is the point.
+	# The branch is the remote's own idea of its default, upstream before
+	# origin; `git remote set-head origin --auto` is what writes that
+	# down, and main stands in where neither says. Name one to override.
+	dzm = "!f() { b=${1:-$(git symbolic-ref --short refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo main)}; git dz $(git merge-base $b HEAD); }; f"
+	# Difftastic compares syntax trees rather than lines, which is what
+	# tells a brace that moved from a line that changed.
+	# --color always because git hands an external diff to the pager, and
+	# a difft that sees a pipe rather than a terminal turns its colour
+	# off; the `less -FRX` in gitconfig passes the escapes through.
+	# An option and then a command, so `dt` takes git diff's arguments.
+	# It is also where completion stops: git's completion reads an alias
+	# word by word to find the command it stands for, and the space inside
+	# the quoted value leaves it holding `always'` -- the price of the
+	# colour, since the value has to be one word to survive that walk.
+	dt = -c diff.external='difft --color always' diff
 	f = fetch --prune
 	fa = fetch --all --prune -j 32
 	lsf = "!f() { if [ ${GIT_PREFIX} != ${PWD} ]; then cd ${GIT_PREFIX}; fi; git ls-files $@ -z | xargs -0 -n1 '-I{}' -- git log -1 --format=%ai\\ {} '{}'; }; f"


### PR DESCRIPTION
Two aliases in the `d` family, and then the commentary they arrived with — plus the
commentary that was already there — moved into the leaf that owns it.

## `dzm` — the diff against the branch this one grew out of

```
dzm = "!f() { b=${1:-$(git symbolic-ref --short refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo main)}; git dz $(git merge-base $b HEAD); }; f"
```

`git dzm` for the default branch, `git dzm upstream/main` or `git dzm release-1.2` for another.

**The merge base is the design, not a detail.** `git difftool --dir-diff` copies edits back
only from the side that *is* the working tree, and the moment two sides are named both
become temporary copies. Measured with a fake difftool that appends a line to the
right-hand tree, then checking whether that line reached the working tree:

| invocation | edits written back |
|---|---|
| `git dz main...` (expands to `main...HEAD`) | **no** |
| `git dz main` | yes |
| `git dz $(git merge-base main HEAD)` | yes |

So `main...`, the spelling that looks right, silently throws away everything typed in Zed.
Naming one side keeps the working tree as the other, and the merge base puts the fork
point opposite it. Plain `main` would work too but drags in whatever the default branch
gained since the fork, shown as your changes reversed.

**The default branch comes from a subprocess**, as you asked: `refs/remotes/upstream/HEAD`,
then `refs/remotes/origin/HEAD`, then `main` — the order `git-pr` already uses. Verified by
pointing a test repo's `origin/HEAD` at a branch called `trunk` and watching `dzm` pick
`merge-base origin/trunk HEAD`.

## `dt` — difftastic

```
dt = -c diff.external='difft --color always' diff
```

Per invocation rather than a setting, so `git diff` stays what it was, and `dt` takes all
of `git diff`'s arguments — `git dt`, `git dt --cached`, `git dt main` all exercised
against difftastic 0.69.0.

`--color always` is not decoration: git hands an external diff to the pager, so difft sees
a pipe and turns its colour off; the `less -FRX` already in `gitconfig` passes the escapes
through. Confirmed both ways.

**The cost, stated on the page:** that space breaks completion, which walks an alias a word
at a time and comes away holding `always'` instead of `diff`. I took the colour; a one-line
`difft-color` wrapper in `rcm/bin/` would buy both if you'd rather.

## The prose moves

`rcm/gitaliases` had grown 25 lines of commentary against 90 lines of aliases, and all of
it was what the tree owns — why a name is the name it is, what `--no-symlinks` is for,
which side of a `--dir-diff` is written back.

* **`config/git-aliases/` gains a section**, *What the longer expansions do*, for the four
  that are not their own explanation: `dz`, `dzm`, `dt`, `wtb`.
* **The push scheme moves into the naming rules**, so the page states it instead of citing
  the file for it, and `wt`'s two letters get the reason they came from git's own
  `--work-tree`.
* **The renamed spellings say what took their work** — `qs` from `sq`, `ff` from `fft`,
  `pr` from `prm`.
* **The file keeps what only it can say**: the section markers, the names left deliberately
  unaliased (`q --hard`, `b -d`, `clean`, `rm`), the source of the squash, and a two-line
  header naming the leaf — so the file is not an orphan, per `meta/handbook/`.

Comment lines in the alias file: 69 → 37.

## Elsewhere

`install/prerequisites/` — Ubuntu 24.04 has no `difft`; Homebrew calls it `difftastic`,
otherwise cargo or a release binary. Its absence is loud (`fatal: external diff died`).
The trie is regenerated: `dt` and `dzm` join the `d` family, `dzm` under `dz`.

Full suite passes.