### PR TITLE
feat(editorconfig): don't strip EOL/EOF whitespace in patches and diffs

### DIFF
--- a/rcm/editorconfig
+++ b/rcm/editorconfig
@@ -17,6 +17,11 @@ tab_width = 4
 [DESCRIPTION]
 trim_trailing_whitespace = false
 
+# Trailing whitespace and the final newline are part of a patch's content
+[*.{patch,diff,rej}]
+insert_final_newline = false
+trim_trailing_whitespace = false
+
 # Tab indentation (no size specified)
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Summary

`rcm/editorconfig` (installed as `~/.editorconfig`) trims trailing
whitespace and forces a final newline for every file, via its `[*]`
section.
For `.patch`, `.diff` and `.rej` files, trailing whitespace and the
presence or absence of a final newline are part of the actual content
being represented, not incidental whitespace — an editor applying the
default rule silently corrupts the file.

This adds an override for `*.{patch,diff,rej}`, following the same
pattern already used for `DESCRIPTION` (whitespace-sensitive R package
files), disabling `trim_trailing_whitespace` and `insert_final_newline`
for those files.

## Test plan

- [x] Verified the file still parses as valid EditorConfig (section
      headers and key/value pairs match the existing format).
- [x] Confirmed no test or handbook page encodes the previous behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FeAKaBvBUMDuVeNJo3DQfx)_