### PR TITLE
fix(zsh): keep the rotation hook from rewriting the history it preloaded

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -19,7 +19,7 @@ and the same question brings both to the same leaf.
   the home-grown layout it replaced
 * [`config/`](config/) — what the installed configuration does:
   the inventory, zsh startup profiling, zsh completion,
-  the prompt marks, the working directory, the editor
+  the prompt marks, the working directory, the history, the editor
 * [`tools/`](tools/) — the scripts that land in `~/bin`,
   grouped by what they are for, each with its status
 * [`testing/`](testing/) — the throw-away home directory,

--- a/handbook/config/README.md
+++ b/handbook/config/README.md
@@ -12,5 +12,6 @@ and how anything gets there at all is
 * [`completion/`](completion/) — zsh completion, audited daily instead of per shell
 * [`prompt-marks/`](prompt-marks/) — every prompt, command and exit status marked for the terminal
 * [`current-directory/`](current-directory/) — the directory the terminal opens the next tab in
+* [`history/`](history/) — every command kept, one file per day, and how a directory of them is repaired
 * [`editor/`](editor/) — the editor every tool is handed, and the widget that hands it the command line
 * [`r-makevars/`](r-makevars/) — what R compiles with, switched per build by an environment variable

--- a/handbook/config/history/README.md
+++ b/handbook/config/history/README.md
@@ -1,0 +1,121 @@
+# The eternal history
+
+Every command every interactive zsh runs is kept,
+in one file per day under `~/.zsh_history.d`,
+reachable from the shell for as far back as the in-memory list goes
+and with `grep` for everything older.
+[`rcm/zshrc`](/rcm/zshrc) is where it is set up,
+and [`rcm/bashrc`](/rcm/bashrc) does the same job for bash.
+
+## The layout
+
+A day-file is named for the day it covers and holds that day's commands,
+so no single file grows without bound
+and a day nobody asks about is never read.
+`legacy.log` beside them holds what a single-file `~/.zsh_history` had
+before the directory existed;
+it is moved there once, the first time the configuration runs.
+
+The day is local time, and the name comes from prompt expansion
+rather than from `date` —
+this runs at every prompt,
+and a fork there would be a fork per command.
+The format string is quoted:
+unquoted, the parameter expansion ends at the first `}` it meets,
+which is the one belonging to `%D`,
+and the second lands in the file name.
+The date is spelled that way twice,
+where `$HISTFILE` is set and again in the rotation hook,
+and only one of the two shows up in the name a shell reports —
+the hook quietly corrects the other,
+which is why both spellings are checked
+([`testing/`](/handbook/testing/README.md)).
+
+## What is in memory, and what is on disk
+
+`SHARE_HISTORY` appends each command to the day-file as it is entered
+and imports what other shells have appended,
+so concurrent sessions stay in sync with no hook of any kind —
+which is what bash needs `PROMPT_COMMAND` for.
+The consequence worth holding on to:
+**the day's commands are on disk before any hook runs.**
+
+Prior days are read back at startup, oldest first, with `fc -R`,
+so that the in-memory list reaches further than today.
+`$HISTFILE` is skipped there, because zsh reads it itself,
+and reading it twice puts every entry in the list twice —
+which the arrow keys then walk through one duplicate at a time.
+
+**The read is eager, and cannot usefully be deferred to the first `Ctrl-R`.**
+`fc -R` appends to the end of the in-memory list,
+so a file read after a prompt has been reached
+lands older commands *after* newer ones,
+and the arrow keys walk them in that order.
+`Ctrl-R` is also not the only thing that list serves:
+`Up`, `Down`, `!!`, `fc` and `history` all read it and nothing else.
+Deferring the cost therefore means giving up the in-memory list
+and letting something outside the shell answer searches instead.
+
+The cost is per line rather than per file —
+measured with zsh 5.9 on Linux, about 13 ms and 5 MB of resident memory
+per megabyte of history read,
+so it is set by how much history there is
+rather than by how many days it is spread over.
+`HISTSIZE` and `SAVEHIST` are both set to ten million in
+[`rcm/zshrc`](/rcm/zshrc),
+which is what stops the list being trimmed at either end.
+
+## Nothing is written when the day turns
+
+The rotation hook runs from `precmd` and does one thing:
+it points `$HISTFILE` at today,
+so that a shell left open overnight starts writing to the new day
+without being restarted.
+
+**It may not write, and neither may anything else on that path.**
+`fc -A` appends every entry zsh did not itself write,
+which is the whole preloaded history and not just the day's commands,
+so a write from this hook copies every prior day
+into the file it is leaving —
+and the next shell preloads that file too.
+`fc -W` is worse, writing the entire list unconditionally.
+Since `SHARE_HISTORY` has already put the day's commands in the day's file,
+there is nothing left for either of them to protect.
+A check pins it, because nothing about a bigger file fails on its own.
+
+The same constraint does not reach bash,
+whose `history -a` appends only the lines the session added
+and excludes what `history -r` read —
+which is why [`rcm/bashrc`](/rcm/bashrc) appends at every prompt
+and this file never does.
+
+## The counts are the point
+
+`HIST_IGNORE_ALL_DUPS` is deliberately off.
+It keeps only the most recent instance of a command,
+which is exactly the frequency information that makes a kept history worth
+keeping: which commands get typed often enough to deserve a script in `~/bin`
+is a question only the counts can answer,
+and the wrapper-script issues in this repository's tracker
+were each found by counting a cluster here.
+`HIST_IGNORE_DUPS` still collapses a command repeated back to back,
+and `HIST_IGNORE_SPACE` keeps a command out of the history altogether
+when it is typed with a leading space.
+
+## Repairing a directory
+
+A directory that was written while the rotation hook did append
+holds each entry once for every day since it was run, and often more.
+[`rcm/bin/zsh-history-repair`](/rcm/bin/zsh-history-repair) puts it back:
+it leaves every timestamped entry exactly once,
+in the file for the day it was run on and in the order it was run,
+with `legacy.log` keeping the entries that carry no timestamp.
+Its `-h` owns the detail, including where the originals are kept.
+
+**What it cannot recover** is the difference between a copy and a genuine
+repeat within one second:
+entries are compared whole, timestamp and elapsed time included,
+so two runs of one command in the same second that also took the same time
+to run collapse into one.
+`HIST_IGNORE_DUPS` had already dropped those where they were typed back to
+back, which is most of them.

--- a/handbook/tools/README.md
+++ b/handbook/tools/README.md
@@ -168,6 +168,15 @@ the three views, and the profiling they sit on, are
 [`config/zsh-startup/`](/handbook/config/zsh-startup/README.md)'s,
 and `-h` prints the commentary in full.
 
+### zsh history
+
+**`zsh-history-repair`** — leave a per-day history directory holding each
+entry once, in the day it was run on;
+it reports and changes nothing until `--apply`,
+and keeps the originals when it does.
+The layout it repairs to, and what a repair cannot recover, are
+[`config/history/`](/handbook/config/history/README.md)'s.
+
 ### R
 
 **`rh`** — start RStudio with an `.Rproj` project file found in the

--- a/rcm/bin/zsh-history-repair
+++ b/rcm/bin/zsh-history-repair
@@ -1,0 +1,378 @@
+#!/usr/bin/env zsh
+#
+# Put a per-day zsh history directory back in order.
+#
+# handbook/config/history/README.md in the scriptlets repository.
+#
+#   zsh-history-repair [--apply] [DIRECTORY]
+#
+# DIRECTORY defaults to ~/.zsh_history.d. Without --apply nothing is written:
+# the report says what would change, and that is the mode to run first.
+#
+# It leaves the directory holding every timestamped entry exactly once, in the
+# file for the day it was run on and in the order it was run; `legacy.log`
+# keeps the entries that carry no timestamp, and nothing else. Day-files whose
+# name carries a stray `}` are renamed. Running it again has nothing to do.
+#
+# Entries are compared whole, timestamp and elapsed time included, so two runs
+# of one command count twice unless they fell in the same second and took the
+# same time -- those collapse, and HIST_IGNORE_DUPS had already dropped them
+# where they were typed back to back.
+#
+# --apply moves the originals to DIRECTORY.backup-<timestamp> rather than
+# deleting them, so the repair is one `mv` from undone.
+#
+# Run it with no other interactive zsh open: today's file is rewritten like any
+# other, and a shell appending to it meanwhile writes into the backup.
+
+emulate -L zsh
+setopt err_exit no_unset pipe_fail extended_glob
+
+zmodload zsh/datetime
+
+case ${1-} in
+-h | --help)
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
+  exit 0
+  ;;
+esac
+
+apply=
+dir=
+
+while (( $# )); do
+  case $1 in
+  --apply) apply=1 ;;
+  -*) print -u2 "unknown option: $1"; exit 2 ;;
+  *)
+    [[ -z $dir ]] || { print -u2 "one directory at a time: $1"; exit 2 }
+    dir=$1
+    ;;
+  esac
+  shift
+done
+
+: ${dir:=$HOME/.zsh_history.d}
+
+[[ -d $dir ]] || { print -u2 "not a directory: $dir"; exit 1 }
+
+# tilde DIRECTORY -- what the report calls a path, so that a home-directory
+# path reads the way it is typed.
+tilde() { print -r -- ${1/#$HOME/\~} }
+
+# thousands NUMBER -- 2431882 as 2,431,882. Counts here run to the millions,
+# which is the whole point of the report, and a run of digits that long says
+# nothing at a glance.
+thousands() {
+  local n=$1 out=
+  while (( ${#n} > 3 )); do
+    out=,${n[-3,-1]}$out
+    n=${n[1,-4]}
+  done
+  print -r -- $n$out
+}
+
+# count NUMBER SINGULAR PLURAL -- the number and the noun that agrees with it.
+count() {
+  if (( $1 == 1 )); then
+    print -r -- "$1 $2"
+  else
+    print -r -- "$(thousands $1) $3"
+  fi
+}
+
+# bytes SIZE -- a size in the unit that makes it readable.
+bytes() {
+  local -a units=(B KB MB GB)
+  local -F size=$1
+  local i=1
+  while (( size >= 1024 && i < $#units )); do
+    (( size = size / 1024.0 ))
+    (( i++ ))
+  done
+  printf '%.1f %s\n' $size $units[i]
+}
+
+# size_of FILE... -- the total size of the files named, in bytes.
+size_of() {
+  local -a sizes
+  local f total=0
+  for f in "$@"; do
+    zstat -A sizes +size -- $f
+    : $(( total += sizes[1] ))
+  done
+  print -r -- $total
+}
+
+zmodload zsh/stat
+
+# --- what to read -----------------------------------------------------------
+#
+# A day-file, with or without the stray brace, and legacy.log. Anything else in
+# the directory is somebody else's and is left alone -- named in the report, so
+# that a file this would have quietly ignored is a file the reader knows about.
+
+typeset -a inputs=( $dir/<->-<->-<->.log(N) $dir/<->-<->-<->\}.log(N) $dir/legacy.log(N) )
+typeset -a ignored=( ${dir}/*(N.^-/) )
+ignored=( ${ignored:|inputs} )
+
+if (( ! $#inputs )); then
+  print -r -- "$(tilde $dir) holds no history files to repair"
+  exit 0
+fi
+
+# Oldest first, so that the sequence numbers below rise with the age of the
+# file: where two copies of an entry share a second, the one in the file that
+# was written first is the one kept.
+inputs=( ${(o)inputs} )
+
+typeset -i read_bytes=$(size_of $inputs)
+
+print -r -- "$(tilde $dir) -- $(count $#inputs file files), $(bytes $read_bytes)"
+print
+
+typeset -a braced=( ${(M)inputs:#*\}.log} )
+if (( $#braced )); then
+  print -r -- "  $(count $#braced "file carries" "files carry") a stray } in the name, from the old HISTFILE spelling"
+fi
+
+# --- the work happens in a staging directory --------------------------------
+#
+# Every history entry passes through here, so the staging files are private from
+# the moment awk creates them rather than from a chmod afterwards.
+
+umask 077
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/zsh-history-repair.XXXXXX")
+staged=$work/staged
+mkdir -p $staged
+
+cleanup() { rm -rf -- $work }
+trap cleanup EXIT INT TERM
+
+# --- pass one: how far back does this history go ----------------------------
+#
+# The day an entry belongs to is a local-time question, and awk cannot answer it
+# portably: strftime is a GNU extension, and macOS ships the one-true awk. So
+# zsh answers it once for every hour in the range and hands awk the table.
+#
+# Splitting entries is the same rule in both passes, and it is zsh's own: an
+# entry is a run of lines where every line but the last ends in a backslash,
+# which is how a command that spans lines is written and how it is read back. A
+# `: <epoch>:<elapsed>;` prefix on the first line is what dates it -- a history
+# written without EXTENDED_HISTORY carries none, and every line stands alone.
+
+typeset -a span=( ${(f)"$(awk '
+  FILENAME != seen_file { seen_file = FILENAME; cont = 0 }
+
+  cont == 0 && /^: [0-9]+:[0-9]*;/ {
+    epoch = substr($0, 3)
+    sub(/:.*/, "", epoch)
+    epoch += 0
+    if (epoch > 0 && (lo == 0 || epoch < lo)) lo = epoch
+    if (epoch > hi) hi = epoch
+  }
+  { cont = (substr($0, length($0), 1) == "\\") }
+  END { print lo+0; print hi+0 }
+' $inputs)"} )
+
+typeset -i lo=$span[1] hi=$span[2]
+
+table=$work/days
+if (( lo > 0 )); then
+  # An hour is the coarsest bucket that never straddles a local midnight, in
+  # every zone anyone has kept history in, so the whole range costs one strftime
+  # per hour rather than one per entry.
+  (( (hi - lo) / 86400 < 36525 )) ||
+    { print -u2 "timestamps span more than a century -- refusing to guess"; exit 1 }
+
+  typeset -a rows=()
+  typeset -i h
+  for (( h = lo / 3600; h <= hi / 3600; h++ )); do
+    rows+=( "$h	$(strftime '%Y-%m-%d' $(( h * 3600 )))" )
+  done
+  print -rl -- $rows > $table
+else
+  : > $table
+fi
+
+# --- pass two: route every entry to the day it was run on -------------------
+#
+# One record per line, so that the rest is `sort`: the day it belongs in, the
+# epoch, the entry's number, the line's number within it, and the day-file it
+# came out of. The entry's own text is the last field and is never parsed again
+# -- it may hold tabs, and every field ahead of it is a date or digits, so the
+# five tabs that delimit them are the first five.
+#
+# An entry with no timestamp cannot be dated and stays in legacy.log, in the
+# order it was read.
+
+awk -v table=$table '
+  BEGIN {
+    FS = "\t"
+    while ((getline row < table) > 0) {
+      split(row, f, "\t")
+      day[f[1]] = f[2]
+    }
+  }
+
+  function flush() {
+    if (! held) return
+    where = epoch > 0 ? day[int(epoch / 3600)] : ""
+    if (where == "") { where = "legacy"; stamp = 0 } else stamp = epoch
+    for (i = 1; i <= held; i++)
+      printf "%s\t%d\t%d\t%d\t%s\t%s\n", where, stamp, seq, i, source, line[i]
+    held = 0
+  }
+
+  # The pending entry belongs to the file that is ending, so it is flushed
+  # before `source` moves on -- and an entry never spans two files, whatever
+  # the last line of this one ends in.
+  FILENAME != seen_file {
+    flush()
+    cont = 0
+    seen_file = FILENAME
+    n = split(FILENAME, parts, "/")
+    source = parts[n]
+    sub(/\.log$/, "", source)
+    sub(/\}$/, "", source)
+  }
+
+  cont == 0 {
+    flush()
+    seq++
+    epoch = 0
+    if ($0 ~ /^: [0-9]+:[0-9]*;/) {
+      epoch = substr($0, 3)
+      sub(/:.*/, "", epoch)
+      epoch += 0
+    }
+  }
+
+  {
+    line[++held] = $0
+    cont = (substr($0, length($0), 1) == "\\")
+  }
+
+  END { flush() }
+' $inputs |
+  LC_ALL=C sort -t'	' -k1,1 -k2,2n -k3,3n -k4,4n > $work/sorted
+
+# --- pass three: one copy of each entry, in the day it belongs to -----------
+#
+# The sort has put every copy of an entry in the same day and the same second,
+# so the duplicates a rotation left behind are near each other and the set of
+# distinct entries being remembered is one day's, not the directory's. It has
+# also put the copy from the oldest file first, which is the copy kept: for
+# every entry but the ones a rotation stranded, that is the original.
+
+typeset -a counts=( ${(f)"$(awk -v out=$staged '
+  BEGIN { FS = "\t" }
+
+  function text() {
+    p = index($0, "\t")
+    for (n = 0; n < 4; n++) p += index(substr($0, p + 1), "\t")
+    return substr($0, p + 1)
+  }
+
+  function flush() {
+    if (! held) return
+    if (! (buffer in seen)) {
+      seen[buffer] = 1
+      printf "%s\n", buffer > file
+      kept++
+      if (from != day) moved++
+    }
+    held = 0
+    buffer = ""
+  }
+
+  {
+    if ($1 != day) {
+      flush()
+      if (day != "") close(file)
+      day = $1
+      file = out "/" day ".log"
+      delete seen
+      files++
+    }
+
+    if ($3 != entry) { flush(); entry = $3; entries++; from = $5 }
+
+    buffer = held ? buffer "\n" text() : text()
+    held++
+  }
+
+  END {
+    flush()
+    print entries+0
+    print kept+0
+    print files+0
+    print moved+0
+  }
+' $work/sorted)"} )
+
+typeset -i entries_read=$counts[1] entries_kept=$counts[2]
+typeset -i files_written=$counts[3] entries_moved=$counts[4]
+
+typeset -a written=( $staged/*.log(N) )
+typeset -i write_bytes=0
+(( ! $#written )) || write_bytes=$(size_of $written)
+
+print -r -- "  $(count $entries_read entry entries) read, $(thousands $entries_kept) of them distinct"
+print -r -- "  $(count $(( entries_read - entries_kept )) "duplicate entry" "duplicate entries") dropped"
+if (( entries_moved )); then
+  print -r -- "  $(count $entries_moved entry entries) stranded in another day's file"
+fi
+print -r -- "  $(count $files_written file files) to write, $(bytes $write_bytes)"
+if (( read_bytes > write_bytes )); then
+  printf '  %d%% of the directory was the same commands written over again\n' \
+    $(( 100 - (100 * write_bytes / read_bytes) ))
+fi
+
+if (( $#ignored )); then
+  print
+  print -r -- "  left alone, not history this writes: ${(j:, :)${(@)ignored:t}}"
+fi
+
+if (( ! $#written )); then
+  print
+  print -r -- "nothing to write -- the history files hold no entries"
+  exit 0
+fi
+
+if [[ -z $apply ]]; then
+  print
+  print -r -- "nothing was changed; pass --apply to write it"
+  exit 0
+fi
+
+# --- swap it in -------------------------------------------------------------
+#
+# The originals move aside as a whole directory rather than file by file: the
+# repair either happened or it did not, and `mv` back is the way out of the
+# second case.
+
+backup=$dir.backup-$(strftime '%Y-%m-%dT%H-%M-%S' $EPOCHSECONDS)
+
+[[ ! -e $backup ]] || { print -u2 "backup directory exists already: $(tilde $backup)"; exit 1 }
+
+mkdir -p -- $backup
+mv -- $inputs $backup/
+
+# Copied rather than moved: $TMPDIR and $HOME are often different file systems,
+# and a rename across one fails.
+#
+# `chmod` without a `--`, which BSD chmod does not take. The mode is asserted
+# rather than left to the umask above, because this is the file the whole
+# history ends up in and nothing else here would notice it being readable.
+for f in $written; do
+  cp -- $f $dir/${f:t}
+  chmod 600 $dir/${f:t}
+done
+
+print
+print -r -- "  originals kept in $(tilde $backup)"
+print -r -- "  wrote $(count $#written file files), $(bytes $(size_of $dir/*.log(N)))"
+print
+print -r -- "open a new shell to pick the repaired history up"

--- a/rcm/zshrc
+++ b/rcm/zshrc
@@ -86,9 +86,9 @@ fi
 # One file per day under a directory, so no single file grows without bound
 # and everything older stays on disk and greppable.
 #
-# What bash needed PROMPT_COMMAND for, zsh does natively: SHARE_HISTORY
-# appends each command as it is entered and imports what other shells have
-# appended, so concurrent sessions stay in sync with no hook.
+# Why the counts are kept rather than the commands deduplicated, why the day's
+# commands are on disk before any hook runs, and what `zsh-history-repair` is
+# for: handbook/config/history/README.md in the scriptlets repository.
 # ---------------------------------------------------------------------------
 HISTSIZE=10000000
 SAVEHIST=$HISTSIZE
@@ -99,10 +99,7 @@ setopt HIST_IGNORE_SPACE    # a leading space keeps a command out
 setopt HIST_IGNORE_DUPS     # collapse an immediate repeat
 setopt HIST_REDUCE_BLANKS
 
-# Deliberate, and the reason is the whole point of keeping history forever:
-# HIST_IGNORE_ALL_DUPS keeps only the most recent instance of a command, which
-# destroys the frequency information. "Which commands do I run enough that they
-# should be scripts in ~/bin" is a question only the counts can answer.
+# Deliberate: this is what keeps the frequency counts.
 unsetopt HIST_IGNORE_ALL_DUPS
 
 __zsh_history_dir="$HOME/.zsh_history.d"
@@ -114,10 +111,13 @@ if [[ -f $HOME/.zsh_history && ! -e $__zsh_history_dir/legacy.log ]]; then
   mv "$HOME/.zsh_history" "$__zsh_history_dir/legacy.log"
 fi
 
-# ${(%):-%D{...}} is strftime via prompt expansion -- the same string $(date)
+# ${(%):-"%D{...}"} is strftime via prompt expansion -- the same string $(date)
 # would give, without the fork. This runs at every prompt below, so a fork here
 # would be a fork per command.
-HISTFILE="$__zsh_history_dir/${(%):-%D{%Y-%m-%d}}.log"
+#
+# The format is quoted, and has to be: unquoted, the expansion ends at the first
+# } it meets, which is %D's own, and the second lands in the file name.
+HISTFILE="$__zsh_history_dir/${(%):-"%D{%Y-%m-%d}"}.log"
 
 # Pull prior days into the in-memory list so Ctrl-R reaches them. Today's file
 # is skipped: zsh loads $HISTFILE itself, and reading it twice duplicates every
@@ -130,14 +130,16 @@ HISTFILE="$__zsh_history_dir/${(%):-%D{%Y-%m-%d}}.log"
   done
 }
 
-# Roll over at midnight without needing a new shell. `fc -A` appends only what
-# is new -- never `fc -W`, which would write the entire preloaded history into
-# today's file and duplicate every prior day.
+# Roll over at midnight without needing a new shell: point HISTFILE at today and
+# nothing else.
+#
+# Nothing is written here, and nothing may be. SHARE_HISTORY has already appended
+# the day's commands to the day's file, and any write from this hook writes the
+# preloaded history with them -- `fc -A` does not exclude what it did not write.
 autoload -Uz add-zsh-hook
 __zsh_history_rotate() {
-  local today="$__zsh_history_dir/${(%):-%D{%Y-%m-%d}}.log"
+  local today="$__zsh_history_dir/${(%):-"%D{%Y-%m-%d}"}.log"
   [[ $HISTFILE == $today ]] && return
-  fc -A
   HISTFILE=$today
 }
 add-zsh-hook precmd __zsh_history_rotate

--- a/tests/checks/61-zsh-history.sh
+++ b/tests/checks/61-zsh-history.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+# The eternal history: what a day-file is called, what reaches the in-memory
+# list, and what the rotation hook is allowed to write.
+#
+# The last of those is the one that earns a check. Rotation used to append, and
+# what it appended was the preloaded history along with the day's own commands,
+# so a day-file grew by the size of every day before it -- daily, compounding,
+# and invisibly, because history that is never read back looks fine on disk.
+# Nothing about a bigger file fails, which is why the guard has to be here.
+#
+# `zsh-history-repair` is the other half: the directories already written that
+# way are repaired rather than abandoned, and the check covers what it promises
+# -- one copy of each entry, in the day it was run on, and nothing touched that
+# is not history.
+
+set -u
+
+. "$(dirname -- "$0")/../lib.sh"
+
+if ! command -v zsh >/dev/null 2>&1; then
+    skip "zsh: not installed"
+    exit 0
+fi
+
+PATH="$HOME/bin:$PATH"
+export PATH
+
+dir=$HOME/.zsh_history.d
+
+# ask INPUT -- what an interactive zsh prints for INPUT, `probe=` lines only.
+#
+# On a pipe rather than through `zsh -ic`: the history hooks run from precmd,
+# and `-c` never reaches a prompt. Which is also why the match is not anchored
+# -- a shell that reaches a prompt sends the prompt marks, and they arrive on
+# the front of the line the answer is on. stderr is dropped, because a
+# system-wide zshrc with opinions of its own is not ours to fix.
+ask() {
+    printf '%s\n' "$1" | zsh -i 2>/dev/null | sed -n 's/.*probe=//p' | tail -n 1
+}
+
+# seed DAY COMMAND -- one entry in DAY's file, stamped inside DAY.
+#
+# The epoch is noon UTC of a date far enough back that no timezone puts it on
+# another day, so the file name and the stamp agree wherever this runs.
+seed() {
+    mkdir -p "$dir"
+    printf ': %s:0;%s\n' "$2" "$3" >>"$dir/$1.log"
+}
+
+# --- the name of a day-file -------------------------------------------------
+#
+# `${(%):-%D{...}}` unquoted ends the expansion at %D's own brace and leaves the
+# second one in the file name, which is how `2026-08-13}.log` came about. The
+# date is spelled twice -- once where $HISTFILE is set, once in the rotation hook
+# -- so the name is asked for twice: `zsh -ic` never reaches a prompt and so
+# reports what ~/.zshrc set, and the directory afterwards reports what the hook
+# did with it. Either spelling alone is a bug, and the hook silently corrects
+# the other one, so neither question catches both.
+
+rm -rf "$dir"
+
+assert_match "the day-file ~/.zshrc names is the day and nothing else" \
+    '*/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].log' \
+    "$(zsh -ic 'print "probe=$HISTFILE"' 2>/dev/null | sed -n 's/.*probe=//p' | tail -n 1)"
+
+rm -rf "$dir"
+
+assert_equal "no day-file is written under any other name" \
+    "" \
+    "$(ask 'print "probe=done"' >/dev/null
+    find "$dir" -type f | sed "s|$dir/||" |
+        grep -v '^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\.log$' || true)"
+
+# --- what the preload reaches -----------------------------------------------
+
+rm -rf "$dir"
+seed 2020-01-02 1577966400 'echo seeded-from-a-prior-day'
+
+assert_equal "a prior day's commands are in the in-memory list" \
+    "1" \
+    "$(ask 'print "probe=$(fc -l 1 | grep -c seeded-from-a-prior-day)"')"
+
+# Today's file is zsh's own $HISTFILE, and reading it a second time would put
+# every entry in the list twice -- which the arrow keys walk through one
+# duplicate at a time.
+rm -rf "$dir"
+mkdir -p "$dir"
+today=$(zsh -c 'print -r -- ${(%):-"%D{%Y-%m-%d}"}')
+printf ': %s:0;%s\n' 1577966400 'echo seeded-into-today' >>"$dir/$today.log"
+
+assert_equal "today's file is read once, not twice" \
+    "1" \
+    "$(ask 'print "probe=$(fc -l 1 | grep -c seeded-into-today)"')"
+
+# --- the rotation hook writes nothing ---------------------------------------
+#
+# $HISTFILE is pointed at a day that is not today -- the state a shell is in
+# when the date turns under it -- and the hook is then called by hand.
+#
+# All on one command line, and it has to be: the hook also runs from precmd, so
+# anything spread over two lines has been rotated back before the second is
+# read, and the branch under test never runs.
+#
+# The command itself is appended to whichever file was $HISTFILE when it was
+# entered, which is today's. So nothing but the hook can write the stale file,
+# and the seeded entries appearing in it is the regression.
+
+rm -rf "$dir"
+seed 2020-01-02 1577966400 'echo seeded-before-rotation'
+seed 2020-01-03 1578052800 'echo also-seeded-before-rotation'
+
+stale=$dir/1999-12-31.log
+
+assert_equal "rotation does not write the preloaded history into the day it leaves" \
+    "0" \
+    "$(ask "HISTFILE=$stale; __zsh_history_rotate; print \"probe=\$(cat $stale 2>/dev/null | grep -c seeded-before-rotation || true)\"")"
+
+assert_match "rotation leaves \$HISTFILE at today's file" \
+    "*/$today.log" \
+    "$(ask "HISTFILE=$stale; __zsh_history_rotate; print \"probe=\$HISTFILE\"")"
+
+# --- zsh-history-repair -----------------------------------------------------
+
+if [ ! -x "$HOME/bin/zsh-history-repair" ]; then
+    fail "zsh-history-repair is installed" "not executable at ~/bin"
+    exit 0
+fi
+
+pass "zsh-history-repair is installed"
+
+# A directory in the state the old rotation left: day-files named with the
+# stray brace, each carrying a verbatim copy of every day before it, one entry
+# stranded in a file for a day it was not run on, and a file that is not
+# history at all.
+#
+# The stamps are noon UTC on three consecutive days in 2020, so the day each
+# entry belongs to is the same wherever this runs.
+rm -rf "$dir"
+mkdir -p "$dir"
+
+one=1577966400  # 2020-01-02 12:00 UTC
+two=1578052800  # 2020-01-03 12:00 UTC
+three=1578139200 # 2020-01-04 12:00 UTC
+
+{
+    printf ': %s:0;echo one\n' "$one"
+    printf ': %s:0;echo spans\\\n' "$one"
+    printf 'two lines\n'
+    printf ': %s:0;echo stranded\n' "$three"
+} >"$dir/2020-01-02}.log"
+
+{
+    printf ': %s:0;echo one\n' "$one"
+    printf ': %s:0;echo spans\\\n' "$one"
+    printf 'two lines\n'
+    printf ': %s:0;echo two\n' "$two"
+} >"$dir/2020-01-03}.log"
+
+printf 'an entry with no timestamp at all\n' >"$dir/legacy.log"
+printf 'not history\n' >"$dir/notes.txt"
+
+report=$(zsh-history-repair --apply "$dir" 2>&1)
+
+# Four entries were run -- `one`, the one that spans two lines, `two`,
+# `stranded` -- against the ten the copies made of them.
+assert_equal "the repair drops the copies a rotation left behind" \
+    "4" \
+    "$(cat "$dir"/2020-01-0*.log | grep -c '^: ')"
+
+assert_equal "each day-file holds the entries stamped inside that day" \
+    "yes" \
+    "$(if [ "$(grep -c "^: $one:" "$dir/2020-01-02.log")" = 2 ] &&
+        [ "$(grep -c "^: $two:" "$dir/2020-01-03.log")" = 1 ] &&
+        [ "$(grep -c "^: $three:" "$dir/2020-01-04.log")" = 1 ]; then
+        echo yes
+    else
+        echo "no
+$report"
+    fi)"
+
+# The continuation is how zsh writes a newline inside a command, so the two
+# lines have to arrive together and in that order, or the command is two.
+assert_equal "a command that spans lines survives whole" \
+    ": $one:0;echo spans\\
+two lines" \
+    "$(sed -n '2,3p' "$dir/2020-01-02.log")"
+
+assert_equal "the entries with no timestamp stay in legacy.log" \
+    "an entry with no timestamp at all" \
+    "$(cat "$dir/legacy.log")"
+
+assert_equal "a file that is not history is left alone" \
+    "not history" \
+    "$(cat "$dir/notes.txt")"
+
+assert_equal "the stray brace is gone from every name" \
+    "" \
+    "$(find "$dir" -name '*}*' | sed "s|$dir/||")"
+
+assert_match "the originals are kept" \
+    "*2020-01-02}.log*" \
+    "$(find "$HOME" -name '2020-01-02}.log' -path '*.backup-*' | head -n 1)"
+
+# Nothing left to do: the promise that makes it safe to run twice, and the one
+# that says the repaired shape is the shape it aims for.
+assert_match "running it again changes nothing" \
+    "*0 duplicate entries dropped*" \
+    "$(zsh-history-repair "$dir" | tr '\n' ' ')"
+
+rm -rf "$dir" "$dir".backup-*


### PR DESCRIPTION
The day-files were growing without bound, and it was not the retention policy — it was the rotation hook writing.

`fc -A` appends every entry zsh did not itself write. The startup preload reads prior days back with `fc -R`, and zsh does not count those as written, so rotating out of a day appended the whole in-memory history to the day-file being left behind. The next shell preloaded that fatter file, and the next rotation wrote it back again.

Reproduced against the history block as it stood, with zsh 5.9 — 100 seed commands, one shell per day, one command per day:

```
day 2026-08-02:    104 lines written to 2026-08-02.log   (total     205)
day 2026-08-03:    210 lines                             (total     415)
day 2026-08-04:    420 lines                             (total     835)
day 2026-08-05:    840 lines                             (total    1675)
day 2026-08-06:   1680 lines                             (total    3355)
day 2026-08-07:   3360 lines                             (total    6715)

history lines on disk: 6715   distinct commands: 113
```

Exact doubling per day, and more than one shell per day makes it worse because each rotating shell writes its own full list. It also explains day-files whose mtime is days after the day they cover: a shell left open across a week still has `$HISTFILE` pointing at the day it started on, and writes a week of accumulated history there at the first prompt after the date turns.

Two consequences worth naming. The frequency counts that `unsetopt HIST_IGNORE_ALL_DUPS` exists to preserve are meaningless while this is happening — `sort | uniq -c` counts rewrites, not runs. And the preload cost is per line, not per file: 13 ms and about 5 MB of resident memory per megabyte read, measured with zsh 5.9 on Linux, so an inflated directory is paid for at every single shell start.

## The fix

Nothing is left for the hook to protect. `SHARE_HISTORY` appends each command to the day-file as it is entered, so the day's commands are on disk before the hook runs, and a command entered while the date turns lands in the file that was current when it was typed — which is the file it belongs in. The hook now points `$HISTFILE` at today and does nothing else. Same simulation, after: 3 lines per day, exactly the commands run.

`${(%):-%D{%Y-%m-%d}}` also needed quoting, which is where `2026-08-13}.log` came from — unquoted, the parameter expansion ends at `%D`'s own brace and the second one lands in the file name. The date is spelled that way twice, and only one of the two shows up in the name a shell reports, because the rotation hook silently corrects the other. Both spellings are checked, since either alone is a bug and neither question catches both.

## `zsh-history-repair`

The directories already written that way are repaired rather than abandoned. `rcm/bin/zsh-history-repair` leaves every timestamped entry exactly once, in the file for the day it was run on and in the order it was run, with `legacy.log` keeping the entries that carry no timestamp. It renames the day-files that carry the stray brace, and running it again has nothing to do.

It reports and changes nothing until `--apply`, and `--apply` moves the originals to `DIRECTORY.backup-<timestamp>` rather than deleting them.

It streams rather than holding the directory in memory: one `awk` pass finds the timestamp range, zsh builds an hour-to-day table (`strftime` in awk is a GNU extension and macOS ships the one-true awk), a second pass emits one line per history line keyed by the day it belongs in, one `sort` groups them, and the dedup then only ever remembers a single day's distinct entries. 8.6 MB of amplified history repairs in 0.9 s; a few hundred megabytes is well under a minute. `umask 077` covers the staging files, and the repaired files are asserted to mode 600 — every entry passes through `$TMPDIR`, and nothing else here would notice them being readable.

Entries are compared whole, timestamp and elapsed time included, so two runs of one command in the same second that also took the same time to run collapse into one. `HIST_IGNORE_DUPS` had already dropped those where they were typed back to back, which is most of them, and the leaf says so.

Multi-line commands are grouped by zsh's own rule — a run of lines where every line but the last ends in a backslash — so an entry that spans lines survives whole, and an entry never spans two files.

## Checks

`61-zsh-history` covers the day-file name from both spellings, that a prior day reaches the in-memory list, that today's file is read once rather than twice, that rotation writes nothing into the day it leaves and does move `$HISTFILE`, and the repair's promises including the multi-line entry, the untimestamped remnant, the file that is not history, and idempotency.

Mutation-tested, each of these turning the suite red on its own: `fc -A` restored, either date spelling unquoted, today's file preloaded, the repair's dedup disabled, its routing disabled, and its entry grouping broken.

The first macOS run caught one of these for real: BSD `chmod` does not take `--`, so under `err_exit` the copy loop died after the first file and the repair wrote one day-file out of four. Fixed, and it is the reason the assertions check the repaired content rather than only the tool's exit status.

## Not in scope

`rcm/bashrc` has the same rotation shape and does not have the same bug — bash's `history -a` appends only what the session added and excludes what `history -r` read, which is why it can append at every prompt. Verified the same way; it stays as it is.

The preload still reads every day-file, so its cost grows by one file a day. That is a separate lever from this fix, and #35 is where it is being pulled — that branch also carries the brace fix and a `handbook/config/history/` leaf of its own, so it will want a merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AQq84fj3hT6W9G3wJx9Ab