### PR TITLE
fix(finicky): move the configuration to Finicky 4's module syntax

### DIFF
--- a/rcm/tag-macos/finicky.js
+++ b/rcm/tag-macos/finicky.js
@@ -1,25 +1,29 @@
-module.exports = {
+// @ts-check
+
+// Finicky 4 reads this file as an ECMAScript module, and hands every callback
+// a standard URL instance rather than the objects Finicky 3 had of its own:
+// https://github.com/johnste/finicky/wiki/Configuration-(v4)
+
+/**
+ * @typedef {import('/Applications/Finicky.app/Contents/Resources/finicky.d.ts').FinickyConfig} FinickyConfig
+ */
+
+/** @type {FinickyConfig} */
+export default {
   // Possible options: ["Google Chrome", "Safari", "Firefox", ...]
   defaultBrowser: "Firefox",
-  options: {
-    // Hide the finicky icon from the top bar
-    //hideIcon: true
-  },
   handlers: [
     {
       match: "http://*.orb.local*",
       browser: "Safari"
     },
     {
-      match: "http://support.posit.co/*",
+      match: ["http://support.posit.co/*", "https://support.posit.co/*"],
       browser: "Safari"
     },
     {
-      match: "https://support.posit.co/*",
-      browser: "Safari"
-    },
-    {
-      match: ({ url }) => url.protocol === "clickup",
+      // A URL instance keeps the colon in the scheme
+      match: (url) => url.protocol === "clickup:",
       browser: "ClickUp"
     },
     {
@@ -29,25 +33,24 @@ module.exports = {
   ],
   rewrite: [
     {
+      // The click tracker ClickUp's notification mails wrap their links in:
+      // https://link-inbox.clickup.com/CL0/https:%2F%2Fapp.clickup.com%2Ft%2F86c1au25p%3Fcomment=90150095296062%26threadedComment=90150095416601%26utm_source=email-notifications%26utm_type=2%26utm_field=comment/1/010001943ba132c9-6ba4ceb3-9da1-4771-8022-60d330932eb7-000000/U4wqDVk2GS865NI30mhkcQc0HqXDzSuXR5-V2AnWBDg=386
       match: "https://link-inbox.clickup.com/CL0/*",
-      url: ({ url }) => ({
-        ...url,
-        protocol: "clickup",
-        host: "",
-        // https://link-inbox.clickup.com/CL0/https:%2F%2Fapp.clickup.com%2Ft%2F86c1au25p%3Fcomment=90150095296062%26threadedComment=90150095416601%26utm_source=email-notifications%26utm_type=2%26utm_field=comment/1/010001943ba132c9-6ba4ceb3-9da1-4771-8022-60d330932eb7-000000/U4wqDVk2GS865NI30mhkcQc0HqXDzSuXR5-V2AnWBDg=386
+      url: (url) => {
         // URL unescape, remove header, remove CL0, remove https://
-        pathname: url.pathname.slice(1).replaceAll("%2F", "/").replaceAll("%3F", "?").replaceAll("%26", "&").replace("CL0/https://", "")
-        // pathname: url.pathname.slice(1).replace("%2F", "/").replace("%2F", "/").replace("%2F", "/").replace("%2F", "/").replace("%2F", "/").replace("%2F", "/").replace("%3F", "?").replace("%26", "&").replace("%26", "&").replace("%26", "&").replace("%26", "&").replace("%26", "&").replace("%26", "&").replace("CL0/https://", "")
-      })
+        const target = url.pathname
+          .slice(1)
+          .replaceAll("%2F", "/")
+          .replaceAll("%3F", "?")
+          .replaceAll("%26", "&")
+          .replace("CL0/https://", "");
+
+        return `clickup://${target}${url.search}${url.hash}`;
+      }
     },
     {
       match: "https://app.clickup.com/*",
-      url: ({ url }) => ({
-        ...url,
-        protocol: "clickup",
-        host: "",
-        pathname: url.pathname.slice(1)
-      })
+      url: (url) => `clickup://${url.pathname.slice(1)}${url.search}${url.hash}`
     },
   ],
 };


### PR DESCRIPTION
Finicky 4 greets the current `rcm/tag-macos/finicky.js` with:

> No default export found for configuration namespace, using legacy configuration. Please update your configuration to use `export default { ... }` instead of `module.exports = { ... }` syntax.

`export default` silences that one, but it is not the only legacy path this configuration was on.

Finicky 4 hands every callback a standard `URL` instance, and the Finicky 3 `url` object that the ClickUp matcher and both rewrites destructured out of the argument is a deprecated property on it that warns whenever it is touched — for the matcher, on every url that does not match an earlier handler first. So the callbacks are rewritten against `URL` too:

- `({ url }) => url.protocol === "clickup"` becomes `(url) => url.protocol === "clickup:"`, because a `URL` keeps the colon in the scheme.
- The two rewrites build the `clickup:` url as a string instead of spreading the old url object into a new one. `search` and `hash` are now carried explicitly, which is what the spread used to do implicitly.

Two things that came along for the ride: the two `support.posit.co` handlers are one handler with an array matcher, and the empty `options` block is gone — it held nothing but a commented-out `hideIcon`. The `// @ts-check` header is [what the wiki suggests](https://github.com/johnste/finicky/wiki/Configuration-(v4)#type-checking) for editor validation; it resolves against the type definitions Finicky ships inside its app bundle, and being comments, it changes nothing at runtime. Say the word and I will drop it.

### Routing is unchanged, and checked rather than eyeballed

Finicky is macOS-only, so I could not run the app here. Instead I ported Finicky 4's evaluation core — its wildcard matcher, `isMatch`, `rewriteUrl`, and the legacy-url compatibility layer, all from `packages/config-api/src` upstream — and ran the old and the new configuration over the same urls, comparing both the browser chosen and the final url handed to it. Every one matches, including:

- `http://foo.orb.local/` and a path-and-query variant, to Safari; `https://foo.orb.local/` to the default browser, as before — the handler still matches `http:` only
- `support.posit.co` over http and https, to Safari, including one with a query and a fragment
- `zoom.us/j/` and `us02web.zoom.us/j/`, to the Zoom bundle id
- `https://app.clickup.com/t/86c1au25p` and variants with a query and a fragment, rewritten to `clickup://t/86c1au25p...` and handed to ClickUp
- the `link-inbox.clickup.com/CL0/…` click-tracker url from the comment in the file, rewritten to exactly the same `clickup://app.clickup.com/t/…` url as before, trailing tracker segments and all
- a plain `clickup://` url, and unrelated urls falling through to Firefox

The same harness counts deprecated-property accesses: one or two per url for the old configuration, zero for the new one.

`mise run test` passes locally (Ubuntu, with `rcm` installed); the file itself is macOS-only and no check reads it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PduUNzDuJ2DsmpEcM7V9aq)_